### PR TITLE
use babel instead of traceur

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -6,5 +6,7 @@
   "node": true,
   "eqeqeq": true,
   "trailing": true,
-  "indent": 2
+  "indent": 2,
+  "esnext": true,
+  "strict": false
 }

--- a/README.md
+++ b/README.md
@@ -5,8 +5,10 @@ Custom plugins used accross appium modules
 
 ## transpile plugin
 
-Traceur compilation, sourcemaps and file renaming functionality in one plugin. `.es7.js` and `.es6.js` files will be automatically
-renamed to `.js files`. The necessary sourcemaps and traceur comments and imports are also automatically added.
+Babel compilation (via Traceur), sourcemaps and file renaming functionality in
+one plugin. `.es7.js` and `.es6.js` files will be automatically renamed to `.js
+files`. The necessary sourcemaps and traceur comments and imports are also
+automatically added.
 
 ### usage
 
@@ -18,7 +20,7 @@ Transpiler = require('appium-gulp-plugins').Transpiler;
 
 gulp.task('transpile', function () {
   var transpiler = new Transpiler();
-  // traceur options are configurable in transpiler.traceurOpts
+  // babel options are configurable in transpiler.babelOpts
 
   return gulp.src('test/fixtures/es7/**/*.js')
     .pipe(transpiler.stream())
@@ -33,24 +35,17 @@ gulp.task('transpile', function () {
 
 Regular lib files do not need any extra comments.
 
-### with gulp-mocha
+### Type assertions
 
-Set the following env variable to skip the traceur runtime declaration.
-
-```js
-process.env.SKIP_TRACEUR_RUNTIME = true;
-```
-
-### rtts-assert
-
-Type assertions may be enable by passing the following
+Type assertions are not yet supported, but if you use Flow you can pass in an
 option to the traspiler:
 
 ```js
 var transpiler = new Transpiler({'rtts-assert': true});
 ```
 
-You may specify type in your code like in the following:
+This will leave the type annotations un-stripped. You may specify type in your
+code like in the following:
 
 ```js
 // The regular way
@@ -62,10 +57,9 @@ let a = function(ti/*:string*/, n/*:number*/)/*:string*/ {return 'let's type cod
 
 ## watch plugin
 
-There are some issues Gulp 3.x error handling which cause the default
-gulp-watch to hang. This pluging is a small hack which solves that by
-respawning the whole process on error. This should not be needed is
-gulp 4.0.
+There are some issues with Gulp 3.x error handling which cause the default
+gulp-watch to hang. This plugin is a small hack which solves that by respawning
+the whole process on error. This should not be needed in gulp 4.0.
 
 ### usage
 
@@ -96,7 +90,6 @@ gulp.task('transpile', function () {
 });
 
 gulp.task('test', ['transpile'] , function () {
-  process.env.SKIP_TRACEUR_RUNTIME = true;
   return gulp.src('build/test/a-specs.js')
     .pipe(mocha())
     .on('error', spawnWatcher.handleError);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,7 +10,7 @@ var gulp = require('gulp'),
     spawnWatcher = require('./index').spawnWatcher.use(gulp),
     runSequence = Q.denodeify(require('run-sequence').use(gulp));
 
-var argv = require('yargs').count('rttsAssert').argv;
+var argv = require('yargs').count('flow').argv;
 
 gulp.task('jscs', function () {
   return gulp
@@ -35,7 +35,7 @@ gulp.task('del-build', function () {
 });
 
 gulp.task('transpile-es7-fixtures', ['del-build'] , function () {
-  var transpiler = new Transpiler(argv.rttsAssert ? {'rtts-assert': true} : null);
+  var transpiler = new Transpiler(argv.flow ? {flow: true} : null);
   return gulp.src('test/fixtures/es7/**/*.js')
     .pipe(transpiler.stream())
     .on('error', spawnWatcher.handleError)
@@ -43,14 +43,12 @@ gulp.task('transpile-es7-fixtures', ['del-build'] , function () {
 });
 
 gulp.task('test-es7-mocha', ['transpile-es7-fixtures'] , function () {
-  process.env.SKIP_TRACEUR_RUNTIME = true;
   return gulp.src('build/test/a-specs.js')
     .pipe(mocha())
     .on('error', spawnWatcher.handleError);
 });
 
 gulp.task('test-es7-mocha-throw', ['transpile-es7-fixtures'] , function () {
-  process.env.SKIP_TRACEUR_RUNTIME = true;
   return gulp.src('build/test/a-throw-specs.js')
     .pipe(mocha())
     .on('error', spawnWatcher.handleError);
@@ -72,4 +70,3 @@ spawnWatcher.configure('watch', ['index.js', 'lib/**/*.js','test/**/*.js','!test
 });
 
 gulp.task('default', ['watch']);
-

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
 exports.Transpiler = require('./lib/transpiler');
 exports.spawnWatcher = require('./lib/spawn-watcher');
+exports.boilerplate = require('./lib/boilerplate');
 

--- a/lib/boilerplate.js
+++ b/lib/boilerplate.js
@@ -1,0 +1,129 @@
+"use strict";
+var mocha = require('gulp-mocha'),
+    Q = require('q'),
+    Transpiler = require('../index').Transpiler,
+    jshint = require('gulp-jshint'),
+    jscs = require('gulp-jscs'),
+    vinylPaths = require('vinyl-paths'),
+    del = require('del'),
+    _ = require('lodash');
+
+var DEFAULT_OPTS = {
+  files: ["*.js", "lib/**/*.js", "test/**/*.js", "!gulpfile.js"],
+  transpile: true,
+  transpileOut: "build",
+  babelOpts: {},
+  linkBabelRuntime: true,
+  jscs: true,
+  jshint: true,
+  watch: true,
+  test: true,
+  testFiles: null,
+  testReporter: 'nyan',
+  testTimeout: 8000,
+  buildName: null
+};
+
+var boilerplate = function (gulp, opts) {
+  var spawnWatcher = require('../index').spawnWatcher.use(gulp);
+  var runSequence = Q.denodeify(require('run-sequence').use(gulp));
+  var defOpts = _.clone(DEFAULT_OPTS);
+  _.extend(defOpts, opts);
+  opts = defOpts;
+
+  process.env.APPIUM_NOTIF_BUILD_NAME = opts.buildName;
+
+  gulp.task('clean', function () {
+    if (opts.transpile) {
+      return gulp.src(opts.transpileOut, {read: false})
+                 .pipe(vinylPaths(del));
+    }
+  });
+
+  if (opts.test) {
+    var testDeps = [];
+    var testDir = 'test';
+    if (opts.transpile) {
+      testDeps.push('transpile');
+      testDir = opts.transpileOut + '/test';
+    }
+
+    var testFiles = opts.testFiles ? opts.testFiles : testDir + '/**/*-specs.js';
+    gulp.task('test', testDeps,  function () {
+      return gulp
+       .src(testFiles, {read: false})
+       .pipe(mocha({reporter: opts.testReporter, timeout: opts.testTimeout}))
+       .on('error', spawnWatcher.handleError);
+    });
+  }
+
+  if (opts.transpile) {
+    gulp.task('transpile', function () {
+      var transpiler = new Transpiler(opts.babelOpts);
+      return gulp.src(opts.files, {base: './'})
+        .pipe(transpiler.stream())
+        .on('error', spawnWatcher.handleError)
+        .pipe(gulp.dest(opts.transpileOut));
+    });
+
+    gulp.task('prepublish', function () {
+      return runSequence('clean', 'transpile');
+    });
+  }
+
+  var lintTasks = [];
+  if (opts.jscs) {
+    gulp.task('jscs', function () {
+    console.log('running jscs');
+      return gulp
+       .src(opts.files)
+       .pipe(jscs())
+       .on('error', spawnWatcher.handleError);
+    });
+    lintTasks.push('jscs');
+  }
+
+  if (opts.jshint) {
+    gulp.task('jshint', function () {
+      return gulp
+       .src(opts.files)
+       .pipe(jshint())
+       .pipe(jshint.reporter('jshint-stylish'))
+       .pipe(jshint.reporter('fail'))
+       .on('error', spawnWatcher.handleError);
+    });
+    lintTasks.push('jshint');
+  }
+
+  if (opts.jscs || opts.jshint) {
+    opts.lint = true;
+    gulp.task('lint', lintTasks);
+  }
+
+  var defaultSequence = [];
+  if (opts.transpile) defaultSequence.push('clean');
+  if (opts.lint) defaultSequence.push('lint');
+  if (opts.transpile) defaultSequence.push('transpile');
+  if (opts.test) defaultSequence.push('test');
+
+  if (opts.watch) {
+    spawnWatcher.clear(false);
+    spawnWatcher.configure('watch', opts.files, function () {
+      return runSequence.apply(null, defaultSequence);
+    });
+  }
+
+  gulp.task('once', function () {
+    return runSequence.apply(null, defaultSequence);
+  });
+
+  gulp.task('default', [opts.watch ? 'watch' : 'once']);
+};
+
+module.exports = {
+  use: function (gulp) {
+    return function (opts) {
+      boilerplate(gulp, opts);
+    };
+  }
+};

--- a/lib/spawn-watcher.js
+++ b/lib/spawn-watcher.js
@@ -72,6 +72,7 @@ module.exports = {
         if (process.argv.indexOf('--no-notif') >= 0) args.push('--no-notif');
         if (respawn) args.push('--respawn');
         args = args.concat(_(process.argv).chain().rest(2).filter(function (arg) {
+          if (/gulp$/.test(arg)) return false;
           return ([taskName, subtaskName, '--no-notif', '--respawn'].indexOf(arg) < 0);
         }).value());
         var proc = spawn('./node_modules/.bin/gulp', args, {stdio: 'inherit'});

--- a/lib/transpiler.js
+++ b/lib/transpiler.js
@@ -1,27 +1,18 @@
 "use strict";
-var traceur = require('gulp-traceur'),
+var babel = require('gulp-babel'),
     replace = require('gulp-replace'),
     rename = require('gulp-rename'),
     _ = require('lodash');
 
-var TRACEUR_OPTS = {
-  asyncFunctions: true,
-  blockBinding: true,
-  modules: 'commonjs',
-  annotations: true,
-  arrayComprehension: true,
+var BABEL_OPTS = {
+  blacklist: ['react'],
+  optional: ['runtime'],
   sourceMaps: 'inline',
+  modules: 'common',
+  stage: 1
 };
 
-var RTTS_ASSERT_OPTS = {
-  types: true,
-  typeAssertions: true,
-  typeAssertionModule: 'appium-transpile-runtime/assets/rtts-assert'
-};
-
-var HEADER =
-  '/*# sourceMappingURL=path/to/source.map*/\n' +
-  'require(\'appium-transpile-runtime\');\n';
+var HEADER = 'require(\'source-map-support\').install();\n\n';
 
 var renameEsX =  function () {
   return rename(function (path) {
@@ -30,14 +21,13 @@ var renameEsX =  function () {
 };
 
 module.exports = function (opts) {
-  opts =opts || {};
-  this.traceurOpts = _.clone(TRACEUR_OPTS);
-  if (opts['rtts-assert']) _.extend(this.traceurOpts, RTTS_ASSERT_OPTS);
+  opts = opts || {};
+  this.babelOpts = _.clone(BABEL_OPTS);
+  if (opts.flow) this.babelOpts.blacklist.push('flow');
   this.header = HEADER;
   this.stream = function () {
     var stream = replace(/\/\/\s+transpile:(main|mocha)\s*/g, this.header);
-    if (opts['rtts-assert']) stream.pipe(replace(/\/\*(:\w+)\*\//g,'$1'));
-    stream.pipe(traceur(this.traceurOpts));
+    stream.pipe(babel(this.babelOpts));
     stream.pipe(renameEsX());
     return stream;
   }.bind(this);

--- a/package.json
+++ b/package.json
@@ -30,18 +30,19 @@
     "gulp-rename": "^1.2.0",
     "gulp-replace": "^0.5.0",
     "gulp-util": "^3.0.1",
-    "lodash": "^2.4.1",
+    "lodash": "^3.6.0",
     "moment": "^2.8.4",
     "node-notifier": "^4.0.3",
     "q": "^1.1.2",
-    "source-map-support": "^0.2.10"
+    "source-map-support": "^0.2.10",
+    "vinyl-paths": "^1.0.0"
   },
   "scripts": {
-    "test": "./node_modules/.bin/gulp once",
-    "watch": "./node_modules/.bin/gulp"
+    "test": "$(npm bin)/gulp once",
+    "watch": "$(npm bin)/gulp"
   },
   "devDependencies": {
-    "chai": "^1.10.0",
+    "chai": "^2.2.0",
     "del": "^1.1.0",
     "gulp": "^3.8.10",
     "gulp-jscs": "^1.3.1",
@@ -52,6 +53,6 @@
     "mochawait": "^1.1.0",
     "run-sequence": "^1.0.2",
     "vargs": "^0.1.0",
-    "yargs": "^1.3.3"
+    "yargs": "^3.7.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,22 +23,24 @@
     "lib": "lib"
   },
   "dependencies": {
+    "babel": "^5.0.12",
+    "babel-runtime": "^5.0.12",
     "clear": "^0.0.1",
+    "gulp-babel": "^5.1.0",
     "gulp-rename": "^1.2.0",
     "gulp-replace": "^0.5.0",
-    "gulp-traceur": "~0.15",
     "gulp-util": "^3.0.1",
     "lodash": "^2.4.1",
     "moment": "^2.8.4",
     "node-notifier": "^4.0.3",
-    "q": "^1.1.2"
+    "q": "^1.1.2",
+    "source-map-support": "^0.2.10"
   },
   "scripts": {
     "test": "./node_modules/.bin/gulp once",
     "watch": "./node_modules/.bin/gulp"
   },
   "devDependencies": {
-    "appium-transpile-runtime": "0.0.4",
     "chai": "^1.10.0",
     "del": "^1.1.0",
     "gulp": "^3.8.10",

--- a/test/fixtures/es7/test/a-specs.es7.js
+++ b/test/fixtures/es7/test/a-specs.es7.js
@@ -1,3 +1,4 @@
+/* global describe:true, it:true */
 // transpile:mocha
 
 import 'mochawait';
@@ -6,10 +7,9 @@ import {A} from '../lib/a';
 
 chai.should();
 
-
 describe('a', () => {
   it('should be able to get text', () => {
-    var a = new A('hello world!');
+    let a = new A('hello world!');
     a.getText().should.equal('hello world!');
   });
 });

--- a/test/fixtures/es7/test/a-throw-specs.es7.js
+++ b/test/fixtures/es7/test/a-throw-specs.es7.js
@@ -6,7 +6,6 @@ import {A} from '../lib/a';
 
 chai.should();
 
-
 describe('a-throw', () => {
   it('should throw', () => {
     var a = new A('hello world!');

--- a/test/transpile-specs.js
+++ b/test/transpile-specs.js
@@ -37,29 +37,13 @@ describe('transpile-specs', function () {
        return readFile('build/lib/a.js', 'utf8');
      }).then(function (content) {
       content.should.have.length.above(0);
-      content.should.not.include('rtts-assert');
-      content.should.include('sourceMapping');
-    });
-  });
-
-  it('should transpile es7 fixtures with rtts-assert enabled', function () {
-    return exec('./node_modules/.bin/gulp transpile-es7-fixtures --rttsAssert')
-      .spread(function (stdout, stderr) {
-        print(stdout, stderr);
-        stderr.should.equal('');
-        stdout.should.include('Finished');
-     }).then(function () {
-       return readFile('build/lib/a.js', 'utf8');
-     }).then(function (content) {
-      content.should.have.length.above(0);
-      content.should.include('rtts-assert');
       content.should.include('sourceMapping');
     });
   });
 
   var checkCode = function (opts) {
     opts = opts || {};
-    var gulpOpts = opts['rtts-assert'] ? ' --rttsAssert' : '';
+    var gulpOpts = opts.flow ? ' --flow' : '';
     before(function () {
       return exec('./node_modules/.bin/gulp transpile-es7-fixtures' + gulpOpts);
     });
@@ -82,27 +66,15 @@ describe('transpile-specs', function () {
       });
     });
 
-    if (opts['rtts-assert']) {
-      it('should detect a rtts-assert error', function () {
-        return exec('node build/lib/rtts-assert-error.js')
-          .spread(function (stdout, stderr) {
-            print(stdout, stderr);
-            stderr.should.equal('');
-            stdout.should.not.include('hello world!');
-            stdout.should.include('Invalid arguments given!');
-         });
-      });
-    } else {
-      it('should not detect a rtts-assert error', function () {
-        return exec('node build/lib/rtts-assert-error.js')
-          .spread(function (stdout, stderr) {
-            print(stdout, stderr);
-            stderr.should.equal('');
-            stdout.should.include('123');
-            stdout.should.not.include('Invalid arguments given!');
-         });
-      });
-    }
+    it('should not detect a rtts-assert error', function () {
+      return exec('node build/lib/rtts-assert-error.js')
+        .spread(function (stdout, stderr) {
+          print(stdout, stderr);
+          stderr.should.equal('');
+          stdout.should.include('123');
+          stdout.should.not.include('Invalid arguments given!');
+       });
+    });
 
     it('should use sourcemap when throwing', function () {
       return exec('node build/lib/throw.js')
@@ -122,7 +94,7 @@ describe('transpile-specs', function () {
           var output = stdout + stderr;
           output.should.include('This is really bad!');
           output.should.include('.es7.js');
-          output.should.include('a-throw-specs.es7.js:13');
+          output.should.include('a-throw-specs.es7.js:12');
        });
     });
 
@@ -151,8 +123,10 @@ describe('transpile-specs', function () {
     checkCode();
   });
 
-  describe('check transpiled code when rtts-assert is enabled', function () {
-   checkCode({'rtts-assert': true});
+  // skip because flow requires extra setup and we might not want to support
+  // it at all
+  describe.skip('check transpiled code when flow is enabled', function () {
+    checkCode({flow: true});
   });
 
 });


### PR DESCRIPTION
@sebv it seems like [babel](http://babeljs.io) is the tool everyone is using for transpiling these days. it uses various other things under the hood. this migrates appium-gulp-plugins over to it.