### PR TITLE
add boilerplate plugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
 exports.Transpiler = require('./lib/transpiler');
 exports.spawnWatcher = require('./lib/spawn-watcher');
+exports.boilerplate = require('./lib/boilerplate');
 

--- a/lib/boilerplate.js
+++ b/lib/boilerplate.js
@@ -1,0 +1,129 @@
+"use strict";
+var mocha = require('gulp-mocha'),
+    Q = require('q'),
+    Transpiler = require('../index').Transpiler,
+    jshint = require('gulp-jshint'),
+    jscs = require('gulp-jscs'),
+    vinylPaths = require('vinyl-paths'),
+    del = require('del'),
+    _ = require('lodash');
+
+var DEFAULT_OPTS = {
+  files: ["*.js", "lib/**/*.js", "test/**/*.js", "!gulpfile.js"],
+  transpile: true,
+  transpileOut: "build",
+  babelOpts: {},
+  linkBabelRuntime: true,
+  jscs: true,
+  jshint: true,
+  watch: true,
+  test: true,
+  testFiles: null,
+  testReporter: 'nyan',
+  testTimeout: 8000,
+  buildName: null
+};
+
+var boilerplate = function (gulp, opts) {
+  var spawnWatcher = require('../index').spawnWatcher.use(gulp);
+  var runSequence = Q.denodeify(require('run-sequence').use(gulp));
+  var defOpts = _.clone(DEFAULT_OPTS);
+  _.extend(defOpts, opts);
+  opts = defOpts;
+
+  process.env.APPIUM_NOTIF_BUILD_NAME = opts.buildName;
+
+  gulp.task('clean', function () {
+    if (opts.transpile) {
+      return gulp.src(opts.transpileOut, {read: false})
+                 .pipe(vinylPaths(del));
+    }
+  });
+
+  if (opts.test) {
+    var testDeps = [];
+    var testDir = 'test';
+    if (opts.transpile) {
+      testDeps.push('transpile');
+      testDir = opts.transpileOut + '/test';
+    }
+
+    var testFiles = opts.testFiles ? opts.testFiles : testDir + '/**/*-specs.js';
+    gulp.task('test', testDeps,  function () {
+      return gulp
+       .src(testFiles, {read: false})
+       .pipe(mocha({reporter: opts.testReporter, timeout: opts.testTimeout}))
+       .on('error', spawnWatcher.handleError);
+    });
+  }
+
+  if (opts.transpile) {
+    gulp.task('transpile', function () {
+      var transpiler = new Transpiler(opts.babelOpts);
+      return gulp.src(opts.files, {base: './'})
+        .pipe(transpiler.stream())
+        .on('error', spawnWatcher.handleError)
+        .pipe(gulp.dest(opts.transpileOut));
+    });
+
+    gulp.task('prepublish', function () {
+      return runSequence('clean', 'transpile');
+    });
+  }
+
+  var lintTasks = [];
+  if (opts.jscs) {
+    gulp.task('jscs', function () {
+    console.log('running jscs');
+      return gulp
+       .src(opts.files)
+       .pipe(jscs())
+       .on('error', spawnWatcher.handleError);
+    });
+    lintTasks.push('jscs');
+  }
+
+  if (opts.jshint) {
+    gulp.task('jshint', function () {
+      return gulp
+       .src(opts.files)
+       .pipe(jshint())
+       .pipe(jshint.reporter('jshint-stylish'))
+       .pipe(jshint.reporter('fail'))
+       .on('error', spawnWatcher.handleError);
+    });
+    lintTasks.push('jshint');
+  }
+
+  if (opts.jscs || opts.jshint) {
+    opts.lint = true;
+    gulp.task('lint', lintTasks);
+  }
+
+  var defaultSequence = [];
+  if (opts.transpile) defaultSequence.push('clean');
+  if (opts.lint) defaultSequence.push('lint');
+  if (opts.transpile) defaultSequence.push('transpile');
+  if (opts.test) defaultSequence.push('test');
+
+  if (opts.watch) {
+    spawnWatcher.clear(false);
+    spawnWatcher.configure('watch', opts.files, function () {
+      return runSequence.apply(null, defaultSequence);
+    });
+  }
+
+  gulp.task('once', function () {
+    return runSequence.apply(null, defaultSequence);
+  });
+
+  gulp.task('default', [opts.watch ? 'watch' : 'once']);
+};
+
+module.exports = {
+  use: function (gulp) {
+    return function (opts) {
+      boilerplate(gulp, opts);
+    };
+  }
+};

--- a/lib/spawn-watcher.js
+++ b/lib/spawn-watcher.js
@@ -72,6 +72,7 @@ module.exports = {
         if (process.argv.indexOf('--no-notif') >= 0) args.push('--no-notif');
         if (respawn) args.push('--respawn');
         args = args.concat(_(process.argv).chain().rest(2).filter(function (arg) {
+          if (/gulp$/.test(arg)) return false;
           return ([taskName, subtaskName, '--no-notif', '--respawn'].indexOf(arg) < 0);
         }).value());
         var proc = spawn('./node_modules/.bin/gulp', args, {stdio: 'inherit'});

--- a/package.json
+++ b/package.json
@@ -30,18 +30,19 @@
     "gulp-rename": "^1.2.0",
     "gulp-replace": "^0.5.0",
     "gulp-util": "^3.0.1",
-    "lodash": "^2.4.1",
+    "lodash": "^3.6.0",
     "moment": "^2.8.4",
     "node-notifier": "^4.0.3",
     "q": "^1.1.2",
-    "source-map-support": "^0.2.10"
+    "source-map-support": "^0.2.10",
+    "vinyl-paths": "^1.0.0"
   },
   "scripts": {
-    "test": "./node_modules/.bin/gulp once",
-    "watch": "./node_modules/.bin/gulp"
+    "test": "$(npm bin)/gulp once",
+    "watch": "$(npm bin)/gulp"
   },
   "devDependencies": {
-    "chai": "^1.10.0",
+    "chai": "^2.2.0",
     "del": "^1.1.0",
     "gulp": "^3.8.10",
     "gulp-jscs": "^1.3.1",
@@ -52,6 +53,6 @@
     "mochawait": "^1.1.0",
     "run-sequence": "^1.0.2",
     "vargs": "^0.1.0",
-    "yargs": "^1.3.3"
+    "yargs": "^3.7.0"
   }
 }


### PR DESCRIPTION
@sebv this makes it really easy to just use one function for all our appium es+ gulp files. we could do for example:

```js
// appium-chromedriver's gulpfile.js
var gulp = require('gulp'),
    boilerplate = require('appium-gulp-plugins').boilerplate.use(gulp);

boilerplate({build: "Appium Chromedriver"});
```

And have it take care of watch, transpile, lint, running tests, etc...

Bunch of config options to use as well.

(merging this into babel branch so it looks clean)