### PR TITLE
add extraPrepublishTasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ var DEFAULT_OPTS = {
   testFiles: null,
   testReporter: 'nyan',
   testTimeout: 8000,
-  buildName: null
+  buildName: null,
+  extraPrepublishTasks: []
 };
 ```
 

--- a/lib/boilerplate.js
+++ b/lib/boilerplate.js
@@ -39,6 +39,7 @@ var DEFAULT_OPTS = {
   testReporter: ( process.env.TRAVIS || process.env.CI ) ? 'spec' : 'nyan',
   testTimeout: 8000,
   buildName: null,
+  extraPrepublishTasks: []
 };
 
 var DEFAULT_ANDROID_E2ETEST_OPTS = {
@@ -210,7 +211,8 @@ var boilerplate = function (gulp, opts) {
     });
 
     gulp.task('prepublish', function () {
-      return runSequence('clean', 'transpile');
+      var tasks = ['clean', 'transpile'].concat(opts.extraPrepublishTasks);
+      return runSequence.apply(this, tasks);
     });
   }
 


### PR DESCRIPTION
@jlipps @sebv 

What do you think about this? adds `extraPrepublishTasks` option which is an array of task names.
So you can define tasks, and add them to be part of 'prepublish' task.