### PR TITLE
allow for optional tasks post transpile before unit tests are run

### DIFF
--- a/lib/boilerplate.js
+++ b/lib/boilerplate.js
@@ -277,7 +277,7 @@ var boilerplate = function (gulp, opts) {
   if (opts.transpile) defaultSequence.push('clean');
   if (opts.lint) defaultSequence.push('lint');
   if (opts.transpile && !opts.test) defaultSequence.push('transpile');
-  if (opts.postTranspile) defaultSequence.concat(opts.postTranspile);
+  if (opts.postTranspile) defaultSequence = defaultSequence.concat(opts.postTranspile);
   if (opts.test) {
     if (opts.watchE2E) {
       defaultSequence.push('test');

--- a/lib/boilerplate.js
+++ b/lib/boilerplate.js
@@ -277,6 +277,7 @@ var boilerplate = function (gulp, opts) {
   if (opts.transpile) defaultSequence.push('clean');
   if (opts.lint) defaultSequence.push('lint');
   if (opts.transpile && !opts.test) defaultSequence.push('transpile');
+  if (opts.postTranspile) defaultSequence.concat(opts.postTranspile);
   if (opts.test) {
     if (opts.watchE2E) {
       defaultSequence.push('test');


### PR DESCRIPTION
CC: @jlipps 

Adding in optional tasks post-transpile/pre-tests should be as simple as this, `extraPrepublishTasks` and `extraDefaultTasks` are used in the same way.

My issue now is actually getting an `exec` task to work, or at least give me some output as to why it doesn't appear to be working.  [Here](https://github.com/appium/node-adb-client/blob/fsm-test/gulpfile.js) I'm trying to run `node-gyp` via `exec`, which I'm guessing is asynchronous meaning the unit-tests are still starting before that build has finished.