### PR TITLE
Properly generating the 'sourceRoot' parameter for IDE debugging support

### DIFF
--- a/lib/boilerplate.js
+++ b/lib/boilerplate.js
@@ -235,7 +235,7 @@ var boilerplate = function (gulp, opts) {
 
   if (opts.transpile) {
     gulp.task('transpile', function () {
-      var transpiler = new Transpiler(opts.babelOpts);
+      var transpiler = new Transpiler(opts);
       return gulp.src(opts.files, {base: './'})
         .pipe(transpiler.stream())
         .on('error', spawnWatcher.handleError)

--- a/lib/transpiler.js
+++ b/lib/transpiler.js
@@ -3,19 +3,27 @@ var babel = require('gulp-babel'),
     replace = require('gulp-replace'),
     rename = require('gulp-rename'),
     _ = require('lodash'),
-    streamCombiner = require('./stream-combiner');
+    streamCombiner = require('./stream-combiner'),
+    sourcemaps = require('gulp-sourcemaps'),
+    path = require('path');
 
 var BABEL_OPTS = {
   blacklist: ['react'],
   optional: ['runtime'],
-  sourceMaps: 'inline',
   modules: 'common',
-  stage: 1
+  stage: 1,
+  sourceMaps: true,
+};
+
+var SOURCEMAP_OPTS = {
+    sourceRoot: function (file) { // Point to source root relative to the transpiled file
+      return path.relative(path.join(file.cwd, file.path), file.base);
+    },
 };
 
 var HEADER = 'require(\'source-map-support\').install();\n\n';
 
-var renameEsX =  function () {
+var renameEsX = function () {
   return rename(function (path) {
     path.basename = path.basename.replace(/\.es[67]$/, '');
   });
@@ -23,15 +31,19 @@ var renameEsX =  function () {
 
 module.exports = function (opts) {
   opts = opts || {};
-  this.babelOpts = _.clone(BABEL_OPTS);
+  this.babelOpts = _.merge({}, BABEL_OPTS, opts.babelOpts);
+  this.sourceMapOpts = _.merge({}, SOURCEMAP_OPTS, opts.sourceMapOpts);
+
   if (opts.flow) this.babelOpts.blacklist.push('flow');
   this.header = HEADER;
   this.stream = function () {
     return streamCombiner(function (source) {
       return source
-        .pipe(babel(this.babelOpts))
-        .pipe(replace(/\/\/\s+transpile:(main|mocha)\s*/g, this.header))
-        .pipe(renameEsX());
+        .pipe(sourcemaps.init())
+          .pipe(babel(this.babelOpts))
+          .pipe(replace(/\/\/\s+transpile:(main|mocha)\s*/g, this.header))
+          .pipe(renameEsX())
+        .pipe(sourcemaps.write(this.sourceMapOpts));
     }.bind(this));
   }.bind(this);
 };

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "gulp-nsp": "^2.3.0",
     "gulp-rename": "^1.2.2",
     "gulp-replace": "^0.5.4",
+    "gulp-sourcemaps": "^2.2.0",
     "gulp-util": "^3.0.7",
     "isparta": "^4.0.0",
     "jshint-stylish": "^2.1.0",


### PR DESCRIPTION
Addressing #22: using `gulp-sourcemaps` to modify the `sourceRoot` and have it generate a relative path to the original file from the transpiled file.

`gulp-babel` doesn't seem to accept a function as its `sourceRoot` parameter, so its inlined source map has to be disabled, otherwise we'd get two source map directives at the end of the transpiled file.

Works well with below launch config using VSCode 1.6.1:
```json
	"type": "node2",
	"sourceMaps": true,
	"outFiles": [
		"${workspaceRoot}/build/**/*.js",
		"${workspaceRoot}/node_modules/*/build/**/*.js"
	]
```

Not sure how to propagate this to every module. Do you guys have to republish every Appium module for these changes to take effect?