### PR TITLE
Use old-style of object literal method

### DIFF
--- a/lib/transpiler.js
+++ b/lib/transpiler.js
@@ -16,7 +16,8 @@ var BABEL_OPTS = {
 };
 
 var SOURCEMAP_OPTS = {
-  sourceRoot (file) { // Point to source root relative to the transpiled file
+  sourceRoot: (file) => { // eslint-disable-line babel/object-shorthand
+    // Point to source root relative to the transpiled file
     return path.relative(path.join(file.cwd, file.path), file.base);
   },
 };


### PR DESCRIPTION
Get rid of the new-style, which was a breaking change for older versions of node (like 0.12).