### PR TITLE
Allow console and mocha exclusive in test mode

### DIFF
--- a/lib/boilerplate.js
+++ b/lib/boilerplate.js
@@ -281,10 +281,19 @@ let boilerplate = function (gulp, opts) {
   }
 
   gulp.task('eslint', function () {
+    let opts = {
+      fix: process.argv.includes('--fix'),
+    };
+    if (process.env._TESTING) {
+      // when running tests, we want to be able to use exclusive tests
+      // and console logging
+      opts.rules = {
+        'no-console': 0,
+        'mocha/no-exclusive-tests': 0,
+      };
+    }
     return gulp.src(['**/*.js', '!node_modules/**', '!build/**'])
-      .pipe(eslint({
-        fix: process.argv.includes('--fix'),
-      }))
+      .pipe(eslint(opts))
       .pipe(eslint.format())
       .pipe(eslint.failAfterError())
       .pipe(gulpIf((file) => file.eslint && file.eslint.fixed, gulp.dest(process.cwd())));
@@ -329,6 +338,8 @@ let boilerplate = function (gulp, opts) {
   }
 
   gulp.task('once', function () {
+    // set env so our code knows when it's being run in a test env
+    process.env._TESTING = 1;
     return runSequence.apply(null, defaultSequence);
   });
 


### PR DESCRIPTION
When testing it is often useful to be able to have mocha [exclusive tests](https://mochajs.org/#exclusive-tests), which are disallowed by our [eslint rules](https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-exclusive-tests.md).

It also useful to be able to `console.log`.

So, when testing, turn those off.