### PR TITLE
Remove exitOnError check

### DIFF
--- a/lib/spawn-watcher.js
+++ b/lib/spawn-watcher.js
@@ -17,7 +17,6 @@ const GULP_EXECUTABLE = path.resolve('.', 'node_modules', '.bin', 'gulp');
 
 let gulp;
 
-let exitOnError = false;
 let clearTerminal = true;
 
 let notify = function (subtitle, message) {
@@ -53,9 +52,7 @@ module.exports = {
     const code = /\u001b\[(\d+(;\d+)*)?m/g; // eslint-disable-line no-control-regex
     const notifyErr = ('' + err).replace(code, '');
     notify('Build failure!', notifyErr);
-    if (exitOnError) {
-      process.exit(1);
-    }
+    process.exit(1);
   },
 
   configure (taskName, filePattern, sequence) {
@@ -72,7 +69,6 @@ module.exports = {
     };
 
     gulp.task(subtaskName, function () {
-      exitOnError = true;
       gulp.watch(filePattern, function watchTask () {
         if (clearTerminal) {
           clear();

--- a/lib/tasks/unit-test.js
+++ b/lib/tasks/unit-test.js
@@ -22,8 +22,8 @@ const configure = function configure (gulp, opts, env) {
       .src(testFiles, {read: false})
       .pipe(gulpIf(isVerbose(), debug()))
       .pipe(mocha(mochaOpts))
-      .once('error', function () {
-        env.spawnWatcher.handleError();
+      .once('error', function (err) {
+        env.spawnWatcher.handleError(err);
       });
   });
   gulp.task('unit-test', gulp.series(...env.testDeps, '_unit-test'));


### PR DESCRIPTION
This flag does not do anything useful. Removing it ensures the correct error code is emitted on failure.

Hopefully this didn't mask too many broken builds... but most of our CI does not use gulp for testing, but directly accesses mocha.