### PR TITLE
Fix calls to Array#reduce

### DIFF
--- a/lib/tasks/e2e-test.js
+++ b/lib/tasks/e2e-test.js
@@ -84,7 +84,7 @@ const configure = function configure (gulp, opts, env) {
     }
 
     // go through the steps to run the test
-    return startupSeq.reduce((step, promise) => promise.then(step), B.resolve())
+    return startupSeq.reduce((promise, step) => promise.then(step), B.resolve())
       .then(function () {
         return globby(e2eTestFiles);
       })
@@ -97,14 +97,14 @@ const configure = function configure (gulp, opts, env) {
         return mochaCmd();
       })
       .then(function () {
-        return cleanupSeq.reduce((step, promise) => promise.then(step), B.resolve())
+        return cleanupSeq.reduce((promise, step) => promise.then(step), B.resolve())
           .finally(function () {
             if (opts.e2eTest.forceExit) {
               process.exit(0);
             }
           });
       }).catch(function (err) {
-        return cleanupSeq.reduce((step, promise) => promise.then(step), B.resolve())
+        return cleanupSeq.reduce((promise, step) => promise.then(step), B.resolve())
           .finally(function () {
             env.spawnWatcher.handleError(err);
           });


### PR DESCRIPTION
I'm not sure how this ever worked, since the arguments to [Array#reduce](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce) are inverted.