### PR TITLE
Add traceWarnings option to unit and e2e tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,23 +28,40 @@ You can pass a lot of options to configure `boilerplate`. Here are the options
 along with their defaults (from `lib/boilerplate.js`):
 
 ```js
-let DEFAULT_OPTS = {
-  files: ["*.js", "lib/**/*.js", "test/**/*.js", "!gulpfile.js"],
+const DEFAULT_OPTS = {
+  files: ['*.js', 'lib/**/*.js', 'test/**/*.js', '!gulpfile.js'],
   transpile: true,
-  transpileOut: "build",
+  transpileOut: 'build',
   typescript: false,
   typescriptOpts: {},
   babelOpts: {},
   linkBabelRuntime: true,
   watch: true,
-  lintOnWatch: false,
-  test: true,
-  testFiles: ['${testDir}/**/*-specs.js', '!${testDir}/**/*-e2e-specs.js'],
-  testReporter: 'nyan',
-  testTimeout: 8000,
+  watchE2E: false,
+  test: {
+    files: ['${testDir}/**/*-specs.js', '!${testDir}/**/*-e2e-specs.js'],
+    traceWarnings: true,
+  },
+  coverage: {
+    files: ['./build/test/**/*-specs.js', '!./build/test/**/*-e2e-specs.js'],
+    verbose: true,
+  },
+  'coverage-e2e': {
+    files: ['./build/test/**/*-e2e-specs.js'],
+    verbose: true,
+  },
+  e2eTest: {
+    files: ['${testDir}/**/*-e2e-specs.js'],
+    forceExit: false,
+    traceWarnings: true,
+  },
+  testReporter: (process.env.TRAVIS || process.env.CI) ? 'spec' : 'nyan',
+  testTimeout: 20000,
   buildName: null,
   extraPrepublishTasks: [],
   eslint: true,
+  eslintOnWatch: false, // deprecated, move to lintOnWatch
+  lintOnWatch: false,
   tslint: false,
 };
 ```

--- a/lib/boilerplate.js
+++ b/lib/boilerplate.js
@@ -22,6 +22,7 @@ const DEFAULT_OPTS = {
   watchE2E: false,
   test: {
     files: ['${testDir}/**/*-specs.js', '!${testDir}/**/*-e2e-specs.js'],
+    traceWarnings: true,
   },
   coverage: {
     files: ['./build/test/**/*-specs.js', '!./build/test/**/*-e2e-specs.js'],
@@ -34,6 +35,7 @@ const DEFAULT_OPTS = {
   e2eTest: {
     files: ['${testDir}/**/*-e2e-specs.js'],
     forceExit: false,
+    traceWarnings: true,
   },
   testReporter: (process.env.TRAVIS || process.env.CI) ? 'spec' : 'nyan',
   testTimeout: 20000,

--- a/lib/tasks/e2e-test.js
+++ b/lib/tasks/e2e-test.js
@@ -26,6 +26,8 @@ const configure = function configure (gulp, opts, env) {
       timeout: opts.testTimeout,
       'require': opts.testRequire || [],
       exit: true,
+      traceWarnings: opts.e2eTest.traceWarnings,
+      traceDeprecation: opts.e2eTest.traceWarnings,
     };
     // set env so our code knows when it's being run in a test env
     process.env._TESTING = 1;

--- a/lib/tasks/unit-test.js
+++ b/lib/tasks/unit-test.js
@@ -15,6 +15,8 @@ const configure = function configure (gulp, opts, env) {
       reporter: utils.getTestReporter(opts),
       timeout: opts.testTimeout,
       exit: true,
+      traceWarnings: opts.test.traceWarnings,
+      traceDeprecation: opts.test.traceWarnings,
     };
     // set env so our code knows when it's being run in a test env
     process.env._TESTING = 1;


### PR DESCRIPTION
I recently needed to trace a Buffer deprecation warning and this makes it much easier to get visibility into such things.