### PR TITLE
Move to async/await

### DIFF
--- a/lib/boilerplate.js
+++ b/lib/boilerplate.js
@@ -1,4 +1,3 @@
-/* eslint promise/prefer-await-to-then: 0 */
 /* eslint promise/prefer-await-to-callbacks: 0 */
 'use strict';
 

--- a/lib/boilerplate.js
+++ b/lib/boilerplate.js
@@ -1,4 +1,3 @@
-/* eslint promise/prefer-await-to-callbacks: 0 */
 'use strict';
 
 const _ = require('lodash');

--- a/lib/sourcemaps.js
+++ b/lib/sourcemaps.js
@@ -4,7 +4,7 @@ const replace = require('gulp-replace');
 
 
 const SOURCEMAP_OPTS = {
-  sourceRoot: function (file) { // eslint-disable-line object-shorthand
+  sourceRoot (file) {
     // Point to source root relative to the transpiled file
     return path.relative(path.join(file.cwd, file.path), file.base);
   },

--- a/lib/spawn-watcher.js
+++ b/lib/spawn-watcher.js
@@ -1,4 +1,3 @@
-/* eslint promise/prefer-await-to-then: 0 */
 /* eslint promise/catch-or-return: 0 */
 'use strict';
 
@@ -71,21 +70,20 @@ module.exports = {
       });
     };
 
-    gulp.task(subtaskName, function () {
-      gulp.watch(filePattern, function watchTask () {
+    gulp.task(subtaskName, async function () {
+      gulp.watch(filePattern, async function watchTask () {
         if (clearTerminal) {
           clear();
         }
-        return watchFn().then(notifyOK);
+        notifyOK(await watchFn());
       });
       gulp.watch(['gulpfile.js'], function () {
         process.exit(0);
       });
 
       if (!isRespawn) {
-        B.delay(500).then(function () {
-          watchFn().then(notifyOK);
-        });
+        await B.delay(500);
+        notifyOK(await watchFn());
       }
     });
 

--- a/lib/spawn-watcher.js
+++ b/lib/spawn-watcher.js
@@ -19,7 +19,9 @@ let gulp;
 let clearTerminal = true;
 
 const notify = function (subtitle, message) {
-  if (process.argv.includes('--no-notif')) return; // eslint-disable-line curly
+  if (process.argv.includes('--no-notif')) {
+    return;
+  }
 
   const title = process.env.APPIUM_NOTIF_BUILD_NAME || 'Appium';
   try {
@@ -100,7 +102,9 @@ module.exports = {
           args.push('--respawn');
         }
         args = args.concat(_.chain(process.argv).tail(2).filter(function (arg) {
-          if (/gulp$/.test(arg)) return false; // eslint-disable-line curly
+          if (/gulp$/.test(arg)) {
+            return false;
+          }
           return ![taskName, subtaskName, '--no-notif', '--respawn'].includes(arg);
         }).value());
         const proc = spawn(GULP_EXECUTABLE, args, {stdio: 'inherit', shell: true});

--- a/lib/tasks/ci.js
+++ b/lib/tasks/ci.js
@@ -1,4 +1,3 @@
-/* eslint-disable promise/prefer-await-to-callbacks */
 const fs = require('fs');
 const path = require('path');
 const log = require('fancy-log');

--- a/lib/tasks/ci.js
+++ b/lib/tasks/ci.js
@@ -20,6 +20,9 @@ const GITHUB_REPO = 'appium-build-store';
 
 const OUTPUT_INTERVAL = 60000;
 
+const MOCHA_PARALLEL_TEST_BROKEN_LINE = `if (value.type === 'test') {`;
+const MOCHA_PARALLEL_TEST_FIXED_LINE = `if (value.type === 'test') {\n        delete value.fn;`;
+
 const configure = function configure (gulp, opts) {
   /**
    * `mocha-parallel-tests` is broken at the moment, so skipped describe blocks fail
@@ -31,7 +34,7 @@ const configure = function configure (gulp, opts) {
 
     try {
       let script = await readFile(filePath, {encoding: 'utf8'});
-      await script.replace(`if (value.type === 'test') {`, `if (value.type === 'test') {\n        delete value.fn;`);
+      script = await script.replace(MOCHA_PARALLEL_TEST_BROKEN_LINE, MOCHA_PARALLEL_TEST_FIXED_LINE);
       await writeFile(filePath, script);
     } catch (err) {
       log.error(`Unable to fix 'mocha-parallel-tests': ${err.message}`);
@@ -64,7 +67,7 @@ const configure = function configure (gulp, opts) {
     const repo = opts.ci.repo || GITHUB_REPO;
     log.info(`Downloading repository: '${owner}/${repo}'`);
     const res = await octokit.repos.getLatestRelease({owner, repo});
-    // go through the assets and fine the correct one
+    // go through the assets and find the correct one
     for (const asset of res.data.assets) {
       if (ASSET_NAME_REGEXP.test(asset.name)) {
         log.info(`Downloading asset from '${asset.browser_download_url}'`);

--- a/lib/tasks/ci.js
+++ b/lib/tasks/ci.js
@@ -1,6 +1,4 @@
-/* eslint-disable promise/prefer-await-to-then */
 /* eslint-disable promise/prefer-await-to-callbacks */
-
 const fs = require('fs');
 const path = require('path');
 const log = require('fancy-log');
@@ -28,21 +26,18 @@ const configure = function configure (gulp, opts) {
    * `mocha-parallel-tests` is broken at the moment, so skipped describe blocks fail
    * the fix is simple, and this patches the error until they fix the package
    **/
-  gulp.task('fix-mocha-parallel-tests', function () {
+  gulp.task('fix-mocha-parallel-tests', async function () {
     const root = opts.projectRoot ? opts.projectRoot : findRoot(__dirname);
     const filePath = path.resolve(root, 'node_modules', 'mocha-parallel-tests', 'dist', 'main', 'util.js');
 
-    return readFile(filePath, {encoding: 'utf8'})
-      .then(function (script) {
-        return script.replace(`if (value.type === 'test') {`, `if (value.type === 'test') {\n        delete value.fn;`);
-      })
-      .then(function (script) {
-        return writeFile(filePath, script);
-      })
-      .catch(function (err) {
-        log.error(`Unable to fix 'mocha-parallel-tests': ${err.message}`);
-        throw err;
-      });
+    try {
+      let script = await readFile(filePath, {encoding: 'utf8'});
+      await script.replace(`if (value.type === 'test') {`, `if (value.type === 'test') {\n        delete value.fn;`);
+      await writeFile(filePath, script);
+    } catch (err) {
+      log.error(`Unable to fix 'mocha-parallel-tests': ${err.message}`);
+      throw err;
+    }
   });
 
 
@@ -61,7 +56,7 @@ const configure = function configure (gulp, opts) {
     done();
   });
 
-  gulp.task('github-download', function () {
+  gulp.task('github-download', async function () {
     log.info('Downloading GitHub asset');
     const tempDir = os.tmpdir();
     log.info(`Temporary directory for download: '${tempDir}'`);
@@ -69,19 +64,13 @@ const configure = function configure (gulp, opts) {
     const owner = opts.ci.owner || GITHUB_OWNER;
     const repo = opts.ci.repo || GITHUB_REPO;
     log.info(`Downloading repository: '${owner}/${repo}'`);
-    return octokit.repos.getLatestRelease({owner, repo})
-      .then(function (res) {
-        // go through the assets and fine the correct one
-        for (const asset of res.data.assets) {
-          if (ASSET_NAME_REGEXP.test(asset.name)) {
-            log.info(`Downloading asset from '${asset.browser_download_url}'`);
-            return asset.browser_download_url;
-          }
-        }
-        throw new Error(`Unable to find Appium build asset`);
-      })
-      .then(function download (url) {
-        return new B((resolve, reject) => {
+    const res = await octokit.repos.getLatestRelease({owner, repo});
+    // go through the assets and fine the correct one
+    for (const asset of res.data.assets) {
+      if (ASSET_NAME_REGEXP.test(asset.name)) {
+        log.info(`Downloading asset from '${asset.browser_download_url}'`);
+        const url = asset.browser_download_url;
+        return new B(function (resolve, reject) {
           request(url)
             .on('error', reject) // handle real errors, like connection errors
             .on('response', function (res) {
@@ -93,10 +82,12 @@ const configure = function configure (gulp, opts) {
             .pipe(fs.createWriteStream(`${tempDir}/appium.zip`))
             .on('close', resolve);
         });
-      });
+      }
+    }
+    throw new Error(`Unable to find Appium build asset`);
   });
 
-  gulp.task('saucelabs-upload', function () {
+  gulp.task('saucelabs-upload', async function () {
     // Find the latest bundle
     log.info('Uploading to Sauce Storage');
     const tempDir = os.tmpdir();
@@ -122,12 +113,10 @@ const configure = function configure (gulp, opts) {
       },
       json: true,
     };
-    return requestPromise(options)
-      .then(function (body) {
-        // username should not end up in the logs
-        body.username = '*'.repeat((body.username || '').length);
-        log.info(`File uploaded: ${JSON.stringify(body)}`);
-      });
+    const body = await requestPromise(options);
+    // username should not end up in the logs
+    body.username = '*'.repeat((body.username || '').length);
+    log.info(`File uploaded: ${JSON.stringify(body)}`);
   });
 
   gulp.task('sauce-storage-upload', gulp.series(['github-authenticate', 'github-download', 'saucelabs-upload']));

--- a/lib/tasks/coverage.js
+++ b/lib/tasks/coverage.js
@@ -1,4 +1,3 @@
-/* eslint promise/prefer-await-to-then: 0 */
 /* eslint promise/prefer-await-to-callbacks: 0 */
 'use strict';
 
@@ -15,57 +14,55 @@ const log = require('fancy-log');
 
 const configure = function configure (gulp, opts, env) {
   let npmBin;
-  gulp.task('npm-bin', function () {
+  gulp.task('npm-bin', async function () {
     if (npmBin) {
       return B.resolve();
     }
-    return exec('npm bin').then(function (bin) {
-      if (Array.isArray(bin)) {
-        bin = bin[0];
-      }
-      npmBin = bin.trim();
-      log(`Determined npm bin: ${npmBin}`);
-    });
+    let bin = await exec('npm bin');
+    if (Array.isArray(bin)) {
+      bin = bin[0];
+    }
+    npmBin = bin.trim();
+    log(`Determined npm bin: ${npmBin}`);
   });
 
   const doCoverage = function doCoverage (taskName, filePatterns, targetDir) {
     const covTestFiles = utils.translatePaths([filePatterns], env.fileAliases);
-    gulp.task(`_${taskName}`, function () {
-      return globby(covTestFiles).then(function (files) {
-        const bins = ['nyc', '_mocha'].reduce(function (bins, item) {
-          bins[item] = path.resolve(npmBin, item);
-          return bins;
-        }, {});
-        const args = [
-          '--reporter=lcov',
-          '--reporter=text-lcov',
-          `--report-dir=${targetDir}`,
-          '--exclude-after-remap=false',
-          bins._mocha,
-          '--reporter=dot',
-          ...files,
-          '--exit',
-        ];
-        let env = _.clone(process.env);
-        env.NO_PRECOMPILE = 1;
-        env._TESTING = 1;
-        env.NODE_ENV = 'coverage';
-        log(`Running command: ${bins.nyc} ${args.join(' ')}`);
-        return new B(function (resolve, reject) {
-          const proc = spawn(bins.nyc, args, {
-            env,
-            stdio: opts.coverage.verbose ? 'inherit' : 'ignore',
-          });
-          proc.on('close', function (code) {
-            if (code === 0) {
-              resolve();
-            } else {
-              reject(new Error(`Coverage command exit code: ${code}`));
-            }
-          });
-          proc.on('error', function (err) {
-            reject(new Error(`Coverage error: ${err}`));
-          });
+    gulp.task(`_${taskName}`, async function () {
+      const files = await globby(covTestFiles);
+      const bins = ['nyc', '_mocha'].reduce(function (bins, item) {
+        bins[item] = path.resolve(npmBin, item);
+        return bins;
+      }, {});
+      const args = [
+        '--reporter=lcov',
+        '--reporter=text-lcov',
+        `--report-dir=${targetDir}`,
+        '--exclude-after-remap=false',
+        bins._mocha,
+        '--reporter=dot',
+        ...files,
+        '--exit',
+      ];
+      let env = _.clone(process.env);
+      env.NO_PRECOMPILE = 1;
+      env._TESTING = 1;
+      env.NODE_ENV = 'coverage';
+      log(`Running command: ${bins.nyc} ${args.join(' ')}`);
+      return new B(function (resolve, reject) {
+        const proc = spawn(bins.nyc, args, {
+          env,
+          stdio: opts.coverage.verbose ? 'inherit' : 'ignore',
+        });
+        proc.on('close', function (code) {
+          if (code === 0) {
+            resolve();
+          } else {
+            reject(new Error(`Coverage command exit code: ${code}`));
+          }
+        });
+        proc.on('error', function (err) {
+          reject(new Error(`Coverage error: ${err}`));
         });
       });
     });

--- a/lib/tasks/coverage.js
+++ b/lib/tasks/coverage.js
@@ -1,4 +1,3 @@
-/* eslint promise/prefer-await-to-callbacks: 0 */
 'use strict';
 
 const B = require('bluebird');

--- a/lib/tasks/e2e-test.js
+++ b/lib/tasks/e2e-test.js
@@ -85,7 +85,7 @@ const configure = function configure (gulp, opts, env) {
 
     try {
       // go through the steps to run the test
-      await B.each(startupSeq, async (step) => await step);
+      await B.each(startupSeq, async (step) => await step());
       const files = await globby(e2eTestFiles);
       // gulp-mocha has an issue where, if there are no files passed from gulp.src,
       // it will just run everything it finds
@@ -94,10 +94,10 @@ const configure = function configure (gulp, opts, env) {
         return;
       }
       await mochaCmd();
-      await B.each(cleanupSeq, async (step) => await step);
+      await B.each(cleanupSeq, async (step) => await step());
     } catch (err) {
       try {
-        await B.each(cleanupSeq, async (step) => await step);
+        await B.each(cleanupSeq, async (step) => await step());
       } finally {
         env.spawnWatcher.handleError(err);
       }

--- a/lib/tasks/e2e-test.js
+++ b/lib/tasks/e2e-test.js
@@ -1,4 +1,3 @@
-/* eslint promise/prefer-await-to-then: 0 */
 /* eslint promise/prefer-await-to-callbacks: 0 */
 'use strict';
 
@@ -20,7 +19,7 @@ const DEFAULT_XCODE_VERSION = '9.2';
 
 const configure = function configure (gulp, opts, env) {
   const e2eTestFiles = utils.translatePaths([opts.e2eTest.files || opts.e2eTestFiles], env.fileAliases);
-  gulp.task('_e2e-test', function () {
+  gulp.task('_e2e-test', async function () {
     const mochaOpts = {
       reporter: utils.getTestReporter(opts),
       timeout: opts.testTimeout,
@@ -85,32 +84,28 @@ const configure = function configure (gulp, opts, env) {
       ]);
     }
 
-    // go through the steps to run the test
-    return startupSeq.reduce((promise, step) => promise.then(step), B.resolve())
-      .then(function () {
-        return globby(e2eTestFiles);
-      })
-      .then(function (files) {
-        // gulp-mocha has an issue where, if there are no files passed from gulp.src,
-        // it will just run everything it finds
-        if (!files.length) {
-          return;
-        }
-        return mochaCmd();
-      })
-      .then(function () {
-        return cleanupSeq.reduce((promise, step) => promise.then(step), B.resolve())
-          .finally(function () {
-            if (opts.e2eTest.forceExit) {
-              process.exit(0);
-            }
-          });
-      }).catch(function (err) {
-        return cleanupSeq.reduce((promise, step) => promise.then(step), B.resolve())
-          .finally(function () {
-            env.spawnWatcher.handleError(err);
-          });
-      });
+    try {
+      // go through the steps to run the test
+      await startupSeq.reduce((promise, step) => promise.then(step), B.resolve());
+      const files = globby(e2eTestFiles);
+      // gulp-mocha has an issue where, if there are no files passed from gulp.src,
+      // it will just run everything it finds
+      if (!files.length) {
+        return;
+      }
+      await mochaCmd();
+      await cleanupSeq.reduce((promise, step) => promise.then(step), B.resolve());
+    } catch (err) {
+      try {
+        await cleanupSeq.reduce((promise, step) => promise.then(step), B.resolve());
+      } finally {
+        env.spawnWatcher.handleError(err);
+      }
+    } finally {
+      if (opts.e2eTest.forceExit) {
+        process.exit(0);
+      }
+    }
   });
   gulp.task('e2e-test', gulp.series(...env.testDeps, '_e2e-test'));
 };

--- a/lib/tasks/e2e-test.js
+++ b/lib/tasks/e2e-test.js
@@ -1,4 +1,3 @@
-/* eslint promise/prefer-await-to-callbacks: 0 */
 'use strict';
 
 const mocha = require('gulp-mocha');
@@ -87,10 +86,11 @@ const configure = function configure (gulp, opts, env) {
     try {
       // go through the steps to run the test
       await startupSeq.reduce((promise, step) => promise.then(step), B.resolve());
-      const files = globby(e2eTestFiles);
+      const files = await globby(e2eTestFiles);
       // gulp-mocha has an issue where, if there are no files passed from gulp.src,
       // it will just run everything it finds
       if (!files.length) {
+        log(`No e2e test files found using '${e2eTestFiles}'`);
         return;
       }
       await mochaCmd();

--- a/lib/tasks/e2e-test.js
+++ b/lib/tasks/e2e-test.js
@@ -72,7 +72,7 @@ const configure = function configure (gulp, opts, env) {
       }
     }
     if (opts.e2eTest.ios) {
-      let xCodeVersion = opts.e2eTest.xCodeVersion || DEFAULT_XCODE_VERSION;
+      const xCodeVersion = opts.e2eTest.xCodeVersion || DEFAULT_XCODE_VERSION;
       startupSeq = [
         function () { return iosTools.killAll(); },
         function () { return iosTools.configureXcode(xCodeVersion); },
@@ -85,7 +85,7 @@ const configure = function configure (gulp, opts, env) {
 
     try {
       // go through the steps to run the test
-      await startupSeq.reduce((promise, step) => promise.then(step), B.resolve());
+      await B.each(startupSeq, async (step) => await step);
       const files = await globby(e2eTestFiles);
       // gulp-mocha has an issue where, if there are no files passed from gulp.src,
       // it will just run everything it finds
@@ -94,10 +94,10 @@ const configure = function configure (gulp, opts, env) {
         return;
       }
       await mochaCmd();
-      await cleanupSeq.reduce((promise, step) => promise.then(step), B.resolve());
+      await B.each(cleanupSeq, async (step) => await step);
     } catch (err) {
       try {
-        await cleanupSeq.reduce((promise, step) => promise.then(step), B.resolve());
+        await B.each(cleanupSeq, async (step) => await step);
       } finally {
         env.spawnWatcher.handleError(err);
       }

--- a/lib/tasks/gradle.js
+++ b/lib/tasks/gradle.js
@@ -1,5 +1,3 @@
-/* eslint-disable promise/prefer-await-to-then */
-
 const argv = require('yargs').argv;
 const replace = require('replace-in-file');
 const log = require('fancy-log');
@@ -12,53 +10,47 @@ function logFileChanges (changes = []) {
 }
 
 const configure = function configure (gulp) {
-  gulp.task('gradle-version-update', function () {
-    let gradleFile;
-    return globby(['app/build.gradle'])
-      .then(function getGradleFile (files) {
-        if (!files.length) {
-          throw new Error('No app/build.gradle file found');
+  gulp.task('gradle-version-update', async function () {
+    const files = await globby(['app/build.gradle']);
+    if (!files.length) {
+      throw new Error('No app/build.gradle file found');
+    }
+    const gradleFile = files[0];
+
+    const version = argv['package-version'];
+    if (!version) {
+      throw new Error('No package version argument (use `--package-version=xxx`)');
+    }
+    if (!semver.valid(version)) {
+      throw new Error(`Invalid version specified '${version}'. Version should be in the form '1.2.3'`);
+    }
+
+    let changedFiles = await replace({
+      files: gradleFile,
+      from: /^\s*versionName\s+['"](.+)['"]$/gm,
+      to: (match) => {
+        log(`Updating gradle build file to version name '${version}'`);
+        // match will be like `versionName '1.2.3'`
+        return match.replace(/\d+\.\d+\.\d+/, version);
+      },
+    });
+    logFileChanges(changedFiles);
+
+    changedFiles = replace({
+      files: gradleFile,
+      from: /^\s*versionCode\s+(.+)$/gm,
+      to: (match) => {
+        // match will be like `versionCode 42`
+        const codeMatch = /\d+/.exec(match.trim());
+        if (!codeMatch) {
+          throw new Error('Unable to find existing version code');
         }
-        return files[0];
-      }).then(function setGradleFile (file) {
-        gradleFile = file;
-      }).then(function getPackageVersion () {
-        // get the version
-        const version = argv['package-version'];
-        if (!version) {
-          throw new Error('No package version argument (use `--package-version=xxx`)');
-        }
-        if (!semver.valid(version)) {
-          throw new Error(`Invalid version specified '${version}'. Version should be in the form '1.2.3'`);
-        }
-        return version;
-      }).then(function updateVersionName (version) {
-        return replace({
-          files: gradleFile,
-          from: /^\s*versionName\s+['"](.+)['"]$/gm,
-          to: (match) => {
-            log(`Updating gradle build file to version name '${version}'`);
-            // match will be like `versionName '1.2.3'`
-            return match.replace(/\d+\.\d+\.\d+/, version);
-          },
-        });
-      }).then(logFileChanges)
-      .then(function updateVersionCode () {
-        return replace({
-          files: gradleFile,
-          from: /^\s*versionCode\s+(.+)$/gm,
-          to: (match) => {
-            // match will be like `versionCode 42`
-            const codeMatch = /\d+/.exec(match.trim());
-            if (!codeMatch) {
-              throw new Error('Unable to find existing version code');
-            }
-            const code = parseInt(codeMatch[0], 10) + 1;
-            log(`Updating gradle build file to version code '${code}'`);
-            return match.replace(/\d+/, code);
-          },
-        });
-      }).then(logFileChanges);
+        const code = parseInt(codeMatch[0], 10) + 1;
+        log(`Updating gradle build file to version code '${code}'`);
+        return match.replace(/\d+/, code);
+      },
+    });
+    logFileChanges(changedFiles);
   });
 };
 

--- a/test/gulpfile-js/generate.js
+++ b/test/gulpfile-js/generate.js
@@ -1,11 +1,9 @@
-/* eslint promise/prefer-await-to-then: 0 */
 'use strict';
 
 const gulp = require('gulp');
-const Transpiler = require('../../index').Transpiler;
-const TsTranspiler = require('../../index').TsTranspiler;
-const spawnWatcher = require('../../index').spawnWatcher.use(gulp);
-const isVerbose = require('../../index').isVerbose;
+const {
+  Transpiler, TsTranspiler, spawnWatcher, isVerbose,
+} = require('../../index');
 const _ = require('lodash');
 const B = require('bluebird');
 const rimraf = B.promisify(require('rimraf'));
@@ -16,21 +14,20 @@ const debug = require('gulp-debug');
 const gulpIf = require('gulp-if');
 
 
-gulp.task('generate-lots-of-files', function () {
-  return rimraf('test/generated/es7 test/generated/ts build/generated').then(function () {
-    return exec('mkdir -p test/generated/es7');
-  }).then(function () {
-    return exec('mkdir -p test/generated/ts');
-  }).then(function () {
-    return B.all([
-      ..._.times(24).map(function (i) {
-        return exec(`cp test/fixtures/es7/lib/a.es7.js test/generated/es7/a${i + 1}.es7.js`);
-      }),
-      ..._.times(24).map(function (i) {
-        return exec(`cp test/fixtures/ts/lib/b.ts test/generated/ts/b${i + 1}.ts`);
-      }),
-    ]);
-  });
+const spawnWatch = spawnWatcher.use(gulp);
+
+gulp.task('generate-lots-of-files', async function () {
+  await rimraf('test/generated/es7 test/generated/ts build/generated');
+  await exec('mkdir -p test/generated/es7');
+  await exec('mkdir -p test/generated/ts');
+  await B.all([
+    ..._.times(24).map(function (i) {
+      return exec(`cp test/fixtures/es7/lib/a.es7.js test/generated/es7/a${i + 1}.es7.js`);
+    }),
+    ..._.times(24).map(function (i) {
+      return exec(`cp test/fixtures/ts/lib/b.ts test/generated/ts/b${i + 1}.ts`);
+    }),
+  ]);
 });
 
 gulp.task('transpile-lots-of-es7-files', function () {
@@ -38,7 +35,7 @@ gulp.task('transpile-lots-of-es7-files', function () {
   return gulp.src('test/generated/es7/**/*.js')
     .pipe(gulpIf(isVerbose(), debug()))
     .pipe(transpiler.stream())
-    .on('error', spawnWatcher.handleError)
+    .on('error', spawnWatch.handleError)
     .pipe(gulp.dest('build/generated'));
 });
 
@@ -47,7 +44,7 @@ gulp.task('transpile-lots-of-ts-files', function () {
   return gulp.src('test/generated/ts/**/*.ts')
     .pipe(gulpIf(isVerbose(), debug()))
     .pipe(transpiler.stream())
-    .on('error', spawnWatcher.handleError)
+    .on('error', spawnWatch.handleError)
     .pipe(gulp.dest('build/generated'));
 });
 
@@ -55,32 +52,28 @@ gulp.task('transpile-lots-of-files',
   gulp.series('generate-lots-of-files', 'transpile-lots-of-es7-files', 'transpile-lots-of-ts-files')
 );
 
-gulp.task('test-transpile-lots-of-es7-files', function testTranspileLotsOfFiles () {
-  let numOfFiles;
-  return glob('test/generated/es7/**/*.js').then(function (files) {
-    numOfFiles = files.length;
-    assert(numOfFiles > 16);
-    return glob('build/generated/a*.js');
-  }).then(function (files) {
-    assert(files.length === numOfFiles);
-    return glob('build/generated/*.es7.js');
-  }).then(function (files) {
-    assert(files.length === 0);
-  });
+gulp.task('test-transpile-lots-of-es7-files', async function testTranspileLotsOfFiles () {
+  let files = await glob('test/generated/es7/**/*.js');
+  const numOfFiles = files.length;
+  assert(numOfFiles > 16);
+
+  files = await glob('build/generated/a*.js');
+  assert(files.length === numOfFiles);
+
+  files = await glob('build/generated/*.es7.js');
+  assert(files.length === 0);
 });
 
-gulp.task('test-transpile-lots-of-ts-files', function testTranspileLotsOfFiles () {
-  let numOfFiles;
-  return glob('test/generated/ts/**/*.ts').then(function (files) {
-    numOfFiles = files.length;
-    assert(numOfFiles > 16);
-    return glob('build/generated/b*.js');
-  }).then(function (files) {
-    assert(files.length === numOfFiles);
-    return glob('build/generated/*.ts');
-  }).then(function (files) {
-    assert(files.length === 0);
-  });
+gulp.task('test-transpile-lots-of-ts-files', async function testTranspileLotsOfFiles () {
+  let files = await glob('test/generated/ts/**/*.ts');
+  const numOfFiles = files.length;
+  assert(numOfFiles > 16);
+
+  files = await glob('build/generated/b*.js');
+  assert(files.length === numOfFiles);
+
+  files = await glob('build/generated/*.ts');
+  assert(files.length === 0);
 });
 
 gulp.task('test-transpile-lots-of-files',

--- a/test/gulpfile-js/generate.js
+++ b/test/gulpfile-js/generate.js
@@ -21,12 +21,16 @@ gulp.task('generate-lots-of-files', async function () {
   await exec('mkdir -p test/generated/es7');
   await exec('mkdir -p test/generated/ts');
   await B.all([
-    ..._.times(24).map(function (i) {
-      return exec(`cp test/fixtures/es7/lib/a.es7.js test/generated/es7/a${i + 1}.es7.js`);
-    }),
-    ..._.times(24).map(function (i) {
-      return exec(`cp test/fixtures/ts/lib/b.ts test/generated/ts/b${i + 1}.ts`);
-    }),
+    ...(
+      _.times(24).map(function (i) {
+        return exec(`cp test/fixtures/es7/lib/a.es7.js test/generated/es7/a${i + 1}.es7.js`);
+      })
+    ),
+    ...(
+      _.times(24).map(function (i) {
+        return exec(`cp test/fixtures/ts/lib/b.ts test/generated/ts/b${i + 1}.ts`);
+      })
+    ),
   ]);
 });
 

--- a/test/gulpfile-js/index.js
+++ b/test/gulpfile-js/index.js
@@ -1,4 +1,3 @@
-/* eslint promise/prefer-await-to-then: 0 */
 'use strict';
 
 const gulp = require('gulp');

--- a/test/gulpfile-js/test-es7.js
+++ b/test/gulpfile-js/test-es7.js
@@ -1,4 +1,3 @@
-/* eslint promise/prefer-await-to-then: 0 */
 'use strict';
 
 const gulp = require('gulp');

--- a/test/gulpfile-js/test-ts.js
+++ b/test/gulpfile-js/test-ts.js
@@ -1,4 +1,3 @@
-/* eslint promise/prefer-await-to-then: 0 */
 'use strict';
 
 const gulp = require('gulp');

--- a/test/transpile-specs.js
+++ b/test/transpile-specs.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 /* eslint-disable promise/prefer-await-to-callbacks */
 /* eslint-disable promise/prefer-await-to-then */
 'use strict';
@@ -8,6 +7,7 @@ import cp from 'child_process';
 import chai from 'chai';
 import fs from 'fs';
 import _ from 'lodash';
+import log from 'fancy-log';
 
 
 chai.should();
@@ -30,10 +30,10 @@ const exec = function exec (...args) {
 const print = function print (stdout, stderr) {
   if (process.env.VERBOSE) {
     if ((stdout || '').length) {
-      console.log(`stdout --> '${stdout}'`);
+      log(`stdout --> '${stdout}'`);
     }
     if ((stderr || '').length) {
-      console.log(`stderr --> '${stderr}'`);
+      log(`stderr --> '${stderr}'`);
     }
   }
 };

--- a/test/transpile-specs.js
+++ b/test/transpile-specs.js
@@ -1,5 +1,4 @@
 /* eslint-disable promise/prefer-await-to-callbacks */
-/* eslint-disable promise/prefer-await-to-then */
 'use strict';
 
 import B from 'bluebird';
@@ -56,23 +55,20 @@ describe('transpile-specs', function () {
   };
 
   for (const [name, files] of _.toPairs(tests)) {
-    it(`should transpile ${name} fixtures`, function () {
-      return exec(`${GULP} transpile-${name}-fixtures`)
-        .spread(function (stdout, stderr) {
-          print(stdout, stderr);
-          stderr.should.eql('');
-          stdout.should.include('Finished');
-        }).then(function () {
-          return readFile(`build/lib/${files.classFile}.js`, 'utf8');
-        }).then(function (content) {
-          content.should.have.length.above(0);
-          content.should.include('sourceMapping');
-        });
+    it(`should transpile ${name} fixtures`, async function () {
+      const [stdout, stderr] = await exec(`${GULP} transpile-${name}-fixtures`);
+      print(stdout, stderr);
+      stderr.should.eql('');
+      stdout.should.include('Finished');
+
+      const content = await readFile(`build/lib/${files.classFile}.js`, 'utf8');
+      content.should.have.length.above(0);
+      content.should.include('sourceMapping');
     });
 
     describe('check transpiled', function () {
-      before(function () {
-        return exec(`${GULP} transpile-fixtures`);
+      before(async function () {
+        await exec(`${GULP} transpile-fixtures`);
       });
 
       it(`should be able to run transpiled ${name} code`, function () {


### PR DESCRIPTION
We now only support Node 8+, so `async`/`await` is available natively. This means the untranspiled code in this package can make use of it, rather than callbacks and promise manipulation.

Get rid of most of the `eslint` disabling, as a result.