### PR TITLE
Clean up notification code

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ const DEFAULT_OPTS = {
   },
   testReporter: (process.env.TRAVIS || process.env.CI) ? 'spec' : 'nyan',
   testTimeout: 20000,
-  buildName: null,
+  build: 'Appium',
   extraPrepublishTasks: [],
   eslint: true,
   eslintOnWatch: false, // deprecated, move to lintOnWatch
@@ -117,8 +117,8 @@ Files in the `/test` directory that are named `.*-specs.js` are run. Tests which
 ### usage
 
 ```js
-let gulp = require('gulp'),
-    spawnWatcher = require('./index').spawnWatcher.use(gulp);
+const gulp = require('gulp');
+const spawnWatcher = require('./index').spawnWatcher.use(gulp, opts);
 
 spawnWatcher.configure('watch', ['lib/**/*.js','test/**/*.js','!test/fixtures'], function () {
   // this is the watch action

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -16,7 +16,7 @@ boilerplate({
     files: ['./build/test/**/*-specs.js', '!./build/test/fixtures', '!./build/test/**/*-e2e-specs.js', '!./build/test/generated'],
     verbose: true,
   },
-  buildName: 'Appium Gulp Plugins',
+  build: 'Appium Gulp Plugins',
   extraDefaultTasks: ['e2e-test', 'test-transpile-lots-of-files'],
   testReporter: 'dot',
   tslint: true,

--- a/lib/boilerplate.js
+++ b/lib/boilerplate.js
@@ -38,7 +38,7 @@ const DEFAULT_OPTS = {
   },
   testReporter: (process.env.TRAVIS || process.env.CI) ? 'spec' : 'nyan',
   testTimeout: 20000,
-  buildName: null,
+  build: 'Appium',
   extraPrepublishTasks: [],
   eslint: true,
   eslintOnWatch: false, // deprecated, move to lintOnWatch
@@ -57,9 +57,14 @@ const DEFAULT_ANDROID_E2ETEST_OPTS = {
 };
 
 const boilerplate = function (gulp, opts) {
-  const spawnWatcher = require('../index').spawnWatcher.use(gulp);
-
   opts = _.merge({}, DEFAULT_OPTS, opts);
+
+  if (!_.isEmpty(opts.buildName)) {
+    log.warn(`The 'buildName' option is deprecated. Use 'build' instead`);
+    opts.build = opts.buildName = opts.build || opts.buildName;
+  }
+
+  const spawnWatcher = require('./spawn-watcher').use(gulp, opts);
 
   if (opts.typescript) {
     // rewrite file matcher to find .ts
@@ -75,7 +80,6 @@ const boilerplate = function (gulp, opts) {
   if (opts.e2eTest.ios) {
     _.defaults(opts.e2eTest, DEFAULT_OPTS.e2eTest);
   }
-  process.env.APPIUM_NOTIF_BUILD_NAME = opts.buildName;
 
   const rootDir = opts.transpile ? opts.transpileOut : '.';
   const fileAliases = {

--- a/lib/spawn-watcher.js
+++ b/lib/spawn-watcher.js
@@ -14,48 +14,51 @@ const path = require('path');
 
 const GULP_EXECUTABLE = path.resolve('.', 'node_modules', '.bin', 'gulp');
 
-let gulp;
-
-let clearTerminal = true;
-
-const notify = function (subtitle, message) {
-  if (process.argv.includes('--no-notif')) {
-    return;
-  }
-
-  const title = process.env.APPIUM_NOTIF_BUILD_NAME || 'Appium';
-  try {
-    notifier.notify({
-      title,
-      subtitle: `${subtitle}  ${moment().format('h:mm:ss')}`,
-      message,
-    });
-  } catch (ign) {
-    log(`Notifier: [${title}] ${message}`);
-  }
-};
-
-const notifyOK = notify.bind(null, 'Build success!', 'All Good!');
+const COLOR_CODE_REGEXP = /\u001b\[(\d+(;\d+)*)?m/g; // eslint-disable-line no-control-regex
 
 module.exports = {
-  use (_gulp) {
-    gulp = _gulp;
+  use (gulp, opts = {}) {
+    this.gulp = gulp;
+    this.title = opts.build || 'Appium';
+    this.clearTerminal = true;
     return this;
   },
 
-  clear (_clearTerminal) {
-    clearTerminal = _clearTerminal;
+  notify (subtitle, message) {
+    if (process.argv.includes('--no-notif')) {
+      return;
+    }
+
+    try {
+      notifier.notify({
+        title: this.title,
+        subtitle: `${subtitle}  ${moment().format('h:mm:ss')}`,
+        message,
+      });
+    } catch (ign) {
+      log(`Notifier: [${this.title}] ${message}`);
+    }
+  },
+
+  notifyOK () {
+    this.notify('Build success!', 'All Good!');
+  },
+
+  clear (clearTerminal) {
+    this.clearTerminal = clearTerminal;
     return this;
   },
 
   handleError (err) {
-    err = '' + err;
-    for (const line of err.split('\n')) {
-      log.error(red(line));
+    // log the error
+    const strErr = '' + err;
+    for (const line of strErr.split('\n')) {
+      log.error('s', red(line));
     }
-    const code = /\u001b\[(\d+(;\d+)*)?m/g; // eslint-disable-line no-control-regex
-    const notifyErr = err.replace(code, '');
-    notify('Build failure!', notifyErr);
+
+    // use the system notifier
+    const notifyErr = strErr.replace(COLOR_CODE_REGEXP, '');
+    this.notify('Build failure!', notifyErr);
     process.exit(1);
   },
 
@@ -63,37 +66,38 @@ module.exports = {
     const subtaskName = `_${taskName}`;
     const isRespawn = process.argv.includes('--respawn');
 
-    const watchFn = function watchSquence () {
-      return new B(function (resolve) {
-        (gulp.series(...sequence, function finishWatchSequence (done) {
+    const watchFn = () => {
+      return new B((resolve) => {
+        (this.gulp.series(...sequence, function finishWatchSequence (done) {
           resolve();
           done();
         }))();
       });
     };
 
-    gulp.task(subtaskName, async function () {
-      gulp.watch(filePattern, async function watchTask () {
-        if (clearTerminal) {
+    this.gulp.task(subtaskName, async () => {
+      this.gulp.watch(filePattern, async () => {
+        if (this.clearTerminal) {
           clear();
         }
-        notifyOK(await watchFn());
+        this.notifyOK(await watchFn());
       });
-      gulp.watch(['gulpfile.js'], function () {
+      this.gulp.watch(['gulpfile.js'], function () {
+        log('Gulpfile has been changed. Exiting');
         process.exit(0);
       });
 
       if (!isRespawn) {
         await B.delay(500);
-        notifyOK(await watchFn());
+        this.notifyOK(await watchFn());
       }
     });
 
-    gulp.task(taskName, function () {
-      if (clearTerminal) {
+    this.gulp.task(taskName, () => {
+      if (this.clearTerminal) {
         clear();
       }
-      let spawnWatch = function (respawn) {
+      const spawnWatch = function (respawn) {
         let args = [subtaskName];
         if (process.argv.includes('--no-notif')) {
           args.push('--no-notif');


### PR DESCRIPTION
We were doing some weird gymnastics to get session-based information to the notifier. This PR moves the code into the exported class and give it access to the opts.

Also, we were taking the option `buildName` but in the `gulpfiles` of **all** the packages send in `build`. So it's easier to deprecate the former and accept the latter, than change the option throughout our code. With this change we get notifier with the actual title!

Before:
<img width="434" alt="screenshot 2019-01-19 13 10 35" src="https://user-images.githubusercontent.com/2614354/51430603-d5d0b480-1beb-11e9-8b95-03b68654156a.png">

After:
<img width="392" alt="screenshot 2019-01-19 13 10 03" src="https://user-images.githubusercontent.com/2614354/51430605-e1bc7680-1beb-11e9-841d-61efc8c477a7.png">