### PR TITLE
Move to new auth system for github

### DIFF
--- a/lib/tasks/ci.js
+++ b/lib/tasks/ci.js
@@ -6,7 +6,7 @@ const requestPromise = require('request-promise');
 const request = require('request');
 const B = require('bluebird');
 const os = require('os');
-const octokit = require('@octokit/rest')();
+const Octokit = require('@octokit/rest');
 const _ = require('lodash');
 
 
@@ -22,6 +22,8 @@ const OUTPUT_INTERVAL = 60000;
 
 const MOCHA_PARALLEL_TEST_BROKEN_LINE = `if (value.type === 'test') {`;
 const MOCHA_PARALLEL_TEST_FIXED_LINE = `if (value.type === 'test') {\n        delete value.fn;`;
+
+let octokit;
 
 const configure = function configure (gulp, opts) {
   const owner = opts.ci.owner || GITHUB_OWNER;
@@ -60,9 +62,8 @@ const configure = function configure (gulp, opts) {
       return;
     }
 
-    octokit.authenticate({
-      type: 'token',
-      token: githubToken,
+    octokit = new Octokit({
+      auth: githubToken,
     });
     done();
   });


### PR DESCRIPTION
[Octokit](https://github.com/octokit/rest.js) has [deprecated the authenticate function](https://github.com/octokit/rest.js/pull/1215) in favor of authenticating in the constructor.