### PR TITLE
Add tasks for the ios test app build process

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,32 @@ Native notification is enabled by default. To disable it use the
 ### collate logging and tests
 Set the environment variable `_FORCE_LOGS`
 
+## iOS app building
+
+This package can create `gulp` tasks for building and cleaning iOS apps. By
+providing an `iosApps` property in the options sent to `boilerplate()` with the
+following:
+```js
+iOSApps: {
+  relativeLocations: {
+    iphoneos: 'relative/path/to/device/app.app',
+    iphonesimulator: 'relative/path/to/sim/app.app',
+  },
+  appName: 'AppName.app',
+},
+```
+This will create a number of `gulp` tasks, centrally one named
+`ios-apps:install`, which will go through the process of cleaning the build,
+building, and putting the products into deterministic places.
+
+The simulator app will be build in `build/Release-iphonesimulator/<appName>`,
+and the real device app will be in `build/Release-iphoneos/<appName>`.
+
+To build for real devices, set the environment variable `IOS_REAL_DEVICE` or
+`REAL_DEVICE`. To specify an `xcconfig` file, set its location in the
+`XCCONFIG_FILE` environment variable.
+
+
 ## hacking this package
 
 ### watch

--- a/lib/tasks/index.js
+++ b/lib/tasks/index.js
@@ -9,6 +9,7 @@ const clean = require('./clean');
 const transpile = require('./transpile');
 const gradle = require('./gradle');
 const ci = require('./ci');
+const iosApps = require('./ios-apps');
 
 
 const configure = function configure (gulp, opts, env) {
@@ -25,6 +26,8 @@ const configure = function configure (gulp, opts, env) {
   gradle.configure(gulp, opts);
 
   ci.configure(gulp, opts);
+
+  iosApps.configure(gulp, opts);
 };
 
 module.exports = {

--- a/lib/tasks/ios-apps.js
+++ b/lib/tasks/ios-apps.js
@@ -1,0 +1,128 @@
+'use strict';
+
+const xcode = require('appium-xcode');
+const path = require('path');
+const log = require('fancy-log');
+const cp = require('child_process');
+const fs = require('fs');
+const _rimraf = require('rimraf');
+const B = require('bluebird');
+const _ = require('lodash');
+
+
+const MAX_BUFFER_SIZE = 524288;
+
+const rimraf = B.promisify(_rimraf);
+const renameFile = B.promisify(fs.rename, {context: fs});
+const exec = B.promisify(cp.exec, {context: cp});
+
+function configure (gulp, opts) {
+  if (_.isEmpty(opts.iosApps)) {
+    // nothing to do
+    return;
+  }
+
+  // extract the paths from the enclosing package configuration
+  const relativeLocations = opts.iosApps.relativeLocations;
+
+  // figure out where things will go in the end
+  const SDKS = {
+    iphonesimulator: {
+      name: 'iphonesimulator',
+      buildPath: path.resolve('build', 'Release-iphonesimulator', opts.iosApps.appName),
+      finalPath: relativeLocations.iphonesimulator
+    },
+    iphoneos: {
+      name: 'iphoneos',
+      buildPath: path.resolve('build', 'Release-iphoneos', opts.iosApps.appName),
+      finalPath: relativeLocations.iphoneos
+    }
+  };
+
+  // the sdks against which we will build
+  let sdks = ['iphonesimulator'];
+  if (process.env.IOS_REAL_DEVICE || process.env.REAL_DEVICE) {
+    sdks.push('iphoneos');
+  }
+
+  let sdkVer;
+  async function getIOSSDK () {
+    if (!sdkVer) {
+      try {
+        sdkVer = await xcode.getMaxIOSSDK();
+      } catch (err) {
+        log(`Unable to get max iOS SDK: ${err.message}`);
+        throw err;
+      }
+    }
+    return sdkVer;
+  }
+
+  async function cleanApp (appRoot, sdk) {
+    log(`Cleaning app for ${sdk} at app root '${appRoot}'`);
+    try {
+      const cmd = `xcodebuild -sdk ${sdk} clean`;
+      await exec(cmd, {cwd: appRoot, maxBuffer: MAX_BUFFER_SIZE});
+    } catch (err) {
+      log(`Failed cleaning app: ${err.message}`);
+      throw err;
+    }
+  }
+
+  gulp.task('ios-apps:clean', async function cleanAll () {
+    log('Cleaning all sdks');
+    const sdkVer = await getIOSSDK();
+    for (const sdk of sdks) {
+      await cleanApp('.', sdk + sdkVer);
+    }
+
+    log('Deleting all apps');
+    const apps = [
+      SDKS.iphonesimulator.buildPath,
+      SDKS.iphonesimulator.finalPath,
+      SDKS.iphoneos.buildPath,
+      SDKS.iphoneos.finalPath,
+    ];
+    for (const app of apps) {
+      log(`Deleting app '${app}'`);
+      await rimraf(app);
+    }
+  });
+
+  async function buildApp (appRoot, sdk) {
+    log(`Building app for ${sdk} at app root '${appRoot}'`);
+    try {
+      let cmd = `xcodebuild -sdk ${sdk}`;
+      if (process.env.XCCONFIG_FILE) {
+        cmd = `${cmd} -xcconfig ${process.env.XCCONFIG_FILE}`;
+      }
+
+      await exec(cmd, {cwd: appRoot, maxBuffer: MAX_BUFFER_SIZE});
+    } catch (err) {
+      log(`Failed building app: ${err.message}`);
+      throw err;
+    }
+  }
+
+  gulp.task('ios-apps:build', async function buildAll () {
+    log('Building all apps');
+    const sdkVer = await getIOSSDK();
+    for (const sdk of sdks) {
+      await buildApp('.', sdk + sdkVer);
+    }
+  });
+
+  gulp.task('ios-apps:rename', async function () {
+    log('Renaming apps');
+    for (const sdk of sdks) {
+      log(`Renaming for ${sdk}`);
+      await renameFile(SDKS[sdk].buildPath, SDKS[sdk].finalPath);
+    }
+  });
+
+  gulp.task('ios-apps:install', gulp.series('ios-apps:clean', 'ios-apps:build', 'ios-apps:rename'));
+}
+
+module.exports = {
+  configure,
+};

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "ajv": "^6.0.0",
     "ansi-red": "^0.1.1",
     "appium-ci": "^0.3.0",
+    "appium-xcode": "^3.7.2",
     "babel-eslint": "^10.0.0",
     "babel-plugin-istanbul": "^5.0.1",
     "babel-plugin-source-map-support": "^2.0.1",


### PR DESCRIPTION
We have two iOS apps we use for testing, and they have two entirely different systems for installing and building ([ios-uicatalog](https://github.com/appium/ios-uicatalog) still uses [grunt](https://gruntjs.com/)!).

Extract out the [gulp](https://gulpjs.com/) tasks from [ios-test-app](https://github.com/appium/ios-test-app) so that the same install procedure can be done for both apps.