### PR TITLE
Revert change to Github authentication

### DIFF
--- a/lib/tasks/ci.js
+++ b/lib/tasks/ci.js
@@ -23,7 +23,7 @@ const OUTPUT_INTERVAL = 60000;
 const MOCHA_PARALLEL_TEST_BROKEN_LINE = `if (value.type === 'test') {`;
 const MOCHA_PARALLEL_TEST_FIXED_LINE = `if (value.type === 'test') {\n        delete value.fn;`;
 
-let octokit;
+const octokit = Octokit();
 
 const configure = function configure (gulp, opts) {
   const owner = opts.ci.owner || GITHUB_OWNER;
@@ -62,8 +62,10 @@ const configure = function configure (gulp, opts) {
       return;
     }
 
-    octokit = new Octokit({
-      auth: githubToken,
+    // this produces a deprecation notice, but the alternative does not work
+    octokit.authenticate({
+      type: 'token',
+      token: githubToken,
     });
     done();
   });


### PR DESCRIPTION
For reasons unknown, the new authorization does not actually work (see, for instance, https://travis-ci.org/appium/appium/jobs/490134094). Reverting since we know the old one works fine.