### PR TITLE
Make traceWarnings option false by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ const DEFAULT_OPTS = {
   watchE2E: false,
   test: {
     files: ['${testDir}/**/*-specs.js', '!${testDir}/**/*-e2e-specs.js'],
-    traceWarnings: true,
+    traceWarnings: false,
   },
   coverage: {
     files: ['./build/test/**/*-specs.js', '!./build/test/**/*-e2e-specs.js'],
@@ -53,7 +53,7 @@ const DEFAULT_OPTS = {
   e2eTest: {
     files: ['${testDir}/**/*-e2e-specs.js'],
     forceExit: false,
-    traceWarnings: true,
+    traceWarnings: false,
   },
   testReporter: (process.env.TRAVIS || process.env.CI) ? 'spec' : 'nyan',
   testTimeout: 20000,

--- a/lib/boilerplate.js
+++ b/lib/boilerplate.js
@@ -21,7 +21,7 @@ const DEFAULT_OPTS = {
   watchE2E: false,
   test: {
     files: ['${testDir}/**/*-specs.js', '!${testDir}/**/*-e2e-specs.js'],
-    traceWarnings: true,
+    traceWarnings: false,
   },
   coverage: {
     files: ['./build/test/**/*-specs.js', '!./build/test/**/*-e2e-specs.js'],
@@ -34,7 +34,7 @@ const DEFAULT_OPTS = {
   e2eTest: {
     files: ['${testDir}/**/*-e2e-specs.js'],
     forceExit: false,
-    traceWarnings: true,
+    traceWarnings: false,
   },
   testReporter: (process.env.TRAVIS || process.env.CI) ? 'spec' : 'nyan',
   testTimeout: 20000,

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "gulp-tslint": "^8.1.3",
     "gulp-typescript": "^5.0.0-alpha.3",
     "lodash": "^4.0.1",
-    "mocha": "^5.0.1",
+    "mocha": "^6.0.0",
     "moment": "^2.12.0",
     "node-notifier": "^5.1.2",
     "nyc": "^13.0.1",


### PR DESCRIPTION
Mocha 6 does not support generic node flags, it seems, which I presume is an oversight. Leaving the ability in our helpers, but making them off by default.

This will allow the various Greenkeeper jobs to pass.