### PR TITLE
Make Node 10 the lowest supported version

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,7 +4,7 @@
       "@babel/preset-env",
       {
         "targets": {
-          "node": "8"
+          "node": "10"
         }
       }
     ]

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
-  - "8"
   - "10"
+  - "12"


### PR DESCRIPTION
Begin the process of removing support for Node 8. This will be a breaking change, and during the Greenkeeper runs we can update the CI for each package.