### PR TITLE
Update logging of changed gradle files

### DIFF
--- a/lib/tasks/gradle.js
+++ b/lib/tasks/gradle.js
@@ -8,6 +8,9 @@ const globby = require('globby');
 
 
 function logFileChanges (changes = []) {
+  // `changes` will have entries like
+  //   { file: "app/build.gradle", hasChanged: true }
+  changes = changes.filter((entry) => entry.hasChanged).map((entry) => entry.file);
   log(`Updated files: ${changes.join(', ')}`);
 }
 

--- a/lib/tasks/gradle.js
+++ b/lib/tasks/gradle.js
@@ -15,7 +15,7 @@ function logFileChanges (changes = []) {
 }
 
 const configure = function configure (gulp) {
-  gulp.task('gradle-version-update', async function gradelVersionUpdate () {
+  gulp.task('gradle-version-update', async function gradleVersionUpdate () {
     const files = await globby(['app/build.gradle']);
     if (!files.length) {
       throw new Error('No app/build.gradle file found');


### PR DESCRIPTION
Recently [replace-in-file](https://www.npmjs.com/package/replace-in-file) was [updated](https://github.com/appium/appium-gulp-plugins/commit/3dfa74ccb73effa7a494f21c637dcb60831116de). The returned changes changed from a simple array of filenames to an array of objects:
```json
[
  {
    "file": "app/build.gradle",
    "hasChanged": true
  }
]
```

This broke the logging during [npm version](https://docs.npmjs.com/cli/version).