### PR TITLE
chore: get rid of appium-ci dependency

### DIFF
--- a/lib/boilerplate.js
+++ b/lib/boilerplate.js
@@ -81,10 +81,6 @@ const boilerplate = function (gulp, opts) {
     _.defaults(opts.e2eTest, DEFAULT_OPTS.e2eTest);
     _.defaults(opts.e2eTest, DEFAULT_ANDROID_E2ETEST_OPTS);
   }
-  // re-defaulting when e2eTest.ios=true
-  if (opts.e2eTest.ios) {
-    _.defaults(opts.e2eTest, DEFAULT_OPTS.e2eTest);
-  }
 
   const rootDir = opts.transpile ? opts.transpileOut : '.';
   const fileAliases = {

--- a/lib/boilerplate.js
+++ b/lib/boilerplate.js
@@ -56,11 +56,6 @@ const DEFAULT_OPTS = {
   },
 };
 
-const DEFAULT_ANDROID_E2ETEST_OPTS = {
-  'android-emu': true,
-  'android-avd': process.env.ANDROID_AVD || 'NEXUS_S_18_X86',
-};
-
 const boilerplate = function (gulp, opts) {
   opts = _.merge({}, DEFAULT_OPTS, opts);
 
@@ -74,12 +69,6 @@ const boilerplate = function (gulp, opts) {
   if (opts.typescript) {
     // rewrite file matcher to find .ts
     opts.files.push('*.ts', '**/*.ts', '!node_modules/**/*.ts');
-  }
-
-  // re-defaulting when e2eTest.android=true
-  if (opts.e2eTest.android) {
-    _.defaults(opts.e2eTest, DEFAULT_OPTS.e2eTest);
-    _.defaults(opts.e2eTest, DEFAULT_ANDROID_E2ETEST_OPTS);
   }
 
   const rootDir = opts.transpile ? opts.transpileOut : '.';

--- a/lib/tasks/e2e-test.js
+++ b/lib/tasks/e2e-test.js
@@ -4,7 +4,6 @@ const mocha = require('gulp-mocha');
 const B = require('bluebird');
 const AndroidEmulator = require('appium-ci').AndroidEmulator;
 const androidTools = require('appium-ci').androidTools;
-const iosTools = require('appium-ci').iosTools;
 const globby = require('globby');
 const debug = require('gulp-debug');
 const gulpIf = require('gulp-if');
@@ -13,8 +12,6 @@ const utils = require('../utils');
 
 
 const { isVerbose } = utils;
-
-const DEFAULT_XCODE_VERSION = '9.2';
 
 const configure = function configure (gulp, opts, env) {
   const e2eTestFiles = utils.translatePaths([opts.e2eTest.files || opts.e2eTestFiles], env.fileAliases);
@@ -70,17 +67,6 @@ const configure = function configure (gulp, opts, env) {
           function killAllEmus () { return androidTools.killAll().catch(cleanupWarn); }
         ]);
       }
-    }
-    if (opts.e2eTest.ios) {
-      const xCodeVersion = opts.e2eTest.xCodeVersion || DEFAULT_XCODE_VERSION;
-      startupSeq = [
-        function killAllSims () { return iosTools.killAll(); },
-        function configureXcode () { return iosTools.configureXcode(xCodeVersion); },
-        function resetSim () { return iosTools.resetSims(); },
-      ];
-      cleanupSeq = cleanupSeq.concat([
-        function killAllSims () { return iosTools.killAll().catch(cleanupWarn); }
-      ]);
     }
 
     try {

--- a/lib/tasks/e2e-test.js
+++ b/lib/tasks/e2e-test.js
@@ -2,8 +2,6 @@
 
 const mocha = require('gulp-mocha');
 const B = require('bluebird');
-const AndroidEmulator = require('appium-ci').AndroidEmulator;
-const androidTools = require('appium-ci').androidTools;
 const globby = require('globby');
 const debug = require('gulp-debug');
 const gulpIf = require('gulp-if');
@@ -42,36 +40,7 @@ const configure = function configure (gulp, opts, env) {
       });
     };
 
-    let startupSeq = [];
-    let cleanupSeq = [];
-    let cleanupWarn = function (err) {
-      log(`Error during cleanup, ignoring: ${err}`);
-    };
-    if (opts.e2eTest.android) {
-      if (opts.e2eTest['android-emu']) {
-        let emu = new AndroidEmulator(opts.e2eTest['android-avd']);
-        startupSeq = [
-          function killAllEmus () { return androidTools.killAll(); },
-          function startNewEmu () { return new B(emu.start()); },
-          function waitForEmu () { return emu.waitTillReady(); }
-        ];
-        cleanupSeq = cleanupSeq.concat([
-          function stopEmu () { return emu.stop(); },
-          function killAllEmus () { return androidTools.killAll().catch(cleanupWarn); }
-        ]);
-      } else {
-        startupSeq = [
-          function killAllEmus () { return androidTools.killAll(); },
-        ];
-        cleanupSeq = cleanupSeq.concat([
-          function killAllEmus () { return androidTools.killAll().catch(cleanupWarn); }
-        ]);
-      }
-    }
-
     try {
-      // go through the steps to run the test
-      await B.each(startupSeq, async (step) => await step());
       const files = await globby(e2eTestFiles);
       // gulp-mocha has an issue where, if there are no files passed from gulp.src,
       // it will just run everything it finds
@@ -80,13 +49,6 @@ const configure = function configure (gulp, opts, env) {
         return;
       }
       await mochaCmd();
-      await B.each(cleanupSeq, async (step) => await step());
-    } catch (err) {
-      try {
-        await B.each(cleanupSeq, async (step) => await step());
-      } finally {
-        env.spawnWatcher.handleError(err);
-      }
     } finally {
       if (opts.e2eTest.forceExit) {
         process.exit(0);

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "@types/node": "^12.0.0",
     "ajv": "^6.0.0",
     "ansi-red": "^0.1.1",
-    "appium-ci": "^0.3.0",
     "babel-eslint": "^10.0.3",
     "babel-plugin-istanbul": "^6.0.0",
     "babel-plugin-source-map-support": "^2.0.1",


### PR DESCRIPTION
We have an old module, `appium-ci` (https://github.com/appium/appium-ci), which has not been maintained in a long time, and should be retired.

The functionality here is for automated simulator/emulator management during e2e tests, which is support we do not use anywhere, since it doesn't work particularly well.