### PR TITLE
chore: remove appium-support use

### DIFF
--- a/lib/tasks/ios-apps.js
+++ b/lib/tasks/ios-apps.js
@@ -4,8 +4,12 @@ const path = require('path');
 const log = require('fancy-log');
 const _ = require('lodash');
 const { exec } = require('../utils');
-const { fs } = require('appium-support');
+const B = require('bluebird');
+const fs = require('fs');
+const rimraf = B.promisify(require('rimraf'));
 
+
+const renameFile = B.promisify(fs.rename, {context: fs});
 
 const MAX_BUFFER_SIZE = 524288;
 
@@ -108,14 +112,13 @@ function configure (gulp, opts) {
     ];
     for (const app of apps) {
       log(`    Deleting app '${app}'`);
-      await fs.rimraf(app);
+      await rimraf(app);
     }
   });
 
   async function buildApp (appRoot, sdk) {
     log(`Building app for ${sdk} at app root '${appRoot}'`);
     try {
-      // let cmd = `xcodebuild -sdk ${sdk}`;
       const cmd = 'xcodebuild';
       let args = ['-sdk', sdk];
       if (process.env.XCCONFIG_FILE) {
@@ -143,7 +146,7 @@ function configure (gulp, opts) {
     for (const sdk of sdks) {
       log(`    Renaming for ${sdk}`);
       log(`        '${SDKS[sdk].buildPath}' => '${SDKS[sdk].finalPath}'`);
-      await fs.rename(SDKS[sdk].buildPath, SDKS[sdk].finalPath);
+      await renameFile(SDKS[sdk].buildPath, SDKS[sdk].finalPath);
     }
   });
 


### PR DESCRIPTION
This package is used to build all the others, so it should not rely on them. I missed this `appium-support` use before.