### PR TITLE
feat: add nullish coalescing and optional chaining

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -13,7 +13,9 @@
     "source-map-support",
     "@babel/plugin-proposal-class-properties",
     "@babel/plugin-transform-runtime",
-    "@babel/plugin-syntax-bigint"
+    "@babel/plugin-syntax-bigint",
+    "@babel/plugin-proposal-nullish-coalescing-operator",
+    "@babel/plugin-proposal-optional-chaining"
   ],
   "comments": false,
   "env": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
   "dependencies": {
     "@babel/core": "^7.0.0",
     "@babel/plugin-proposal-class-properties": "^7.0.0",
+    "@babel/plugin-proposal-nullish-coalescing-operator": "^7.8.3",
+    "@babel/plugin-proposal-optional-chaining": "^7.8.3",
     "@babel/plugin-syntax-bigint": "^7.0.0",
     "@babel/plugin-transform-runtime": "^7.0.0",
     "@babel/preset-env": "^7.0.0",


### PR DESCRIPTION
Add support for using ["nullish coaliscing"](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator) (through [babel plugin](https://babeljs.io/docs/en/babel-plugin-proposal-nullish-coalescing-operator)) and ["optional chaining"](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) (through [babel plugin](https://babeljs.io/docs/en/babel-plugin-proposal-optional-chaining)).