### PR TITLE
feat: add class properties and private methods

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -11,11 +11,12 @@
   ],
   "plugins": [
     "source-map-support",
-    "@babel/plugin-proposal-class-properties",
     "@babel/plugin-transform-runtime",
     "@babel/plugin-syntax-bigint",
     "@babel/plugin-proposal-nullish-coalescing-operator",
-    "@babel/plugin-proposal-optional-chaining"
+    "@babel/plugin-proposal-optional-chaining",
+    ["@babel/plugin-proposal-private-methods", {"loose": true}],
+    ["@babel/plugin-proposal-class-properties", {"loose": true}]
   ],
   "comments": false,
   "env": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
   ],
   "dependencies": {
     "@babel/core": "^7.0.0",
-    "@babel/plugin-proposal-class-properties": "^7.0.0",
+    "@babel/plugin-proposal-class-properties": "^7.8.3",
+    "@babel/plugin-proposal-private-methods": "^7.8.3",
     "@babel/plugin-proposal-nullish-coalescing-operator": "^7.8.3",
     "@babel/plugin-proposal-optional-chaining": "^7.8.3",
     "@babel/plugin-syntax-bigint": "^7.0.0",


### PR DESCRIPTION
All the machinations of keeping "private" variables (`this._contexts` and whatnot) can be removed.

Add [class properties](https://babeljs.io/docs/en/babel-plugin-proposal-class-properties) and [private methods](https://babeljs.io/docs/en/babel-plugin-proposal-private-methods) to our babel configuration.