### PR TITLE
feat: add babel numeric separator plugin

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -14,6 +14,7 @@
     "@babel/plugin-transform-runtime",
     "@babel/plugin-syntax-bigint",
     "@babel/plugin-proposal-nullish-coalescing-operator",
+    "@babel/plugin-proposal-numeric-separator",
     "@babel/plugin-proposal-optional-chaining",
     ["@babel/plugin-proposal-private-methods", {"loose": true}],
     ["@babel/plugin-proposal-class-properties", {"loose": true}]

--- a/package.json
+++ b/package.json
@@ -34,9 +34,10 @@
   "dependencies": {
     "@babel/core": "^7.0.0",
     "@babel/plugin-proposal-class-properties": "^7.8.3",
-    "@babel/plugin-proposal-private-methods": "^7.8.3",
     "@babel/plugin-proposal-nullish-coalescing-operator": "^7.8.3",
+    "@babel/plugin-proposal-numeric-separator": "^7.8.3",
     "@babel/plugin-proposal-optional-chaining": "^7.8.3",
+    "@babel/plugin-proposal-private-methods": "^7.8.3",
     "@babel/plugin-syntax-bigint": "^7.0.0",
     "@babel/plugin-transform-runtime": "^7.0.0",
     "@babel/preset-env": "^7.0.0",


### PR DESCRIPTION
Add [plugin](https://babeljs.io/docs/en/babel-plugin-proposal-numeric-separator) for [numeric separator proposal](https://github.com/tc39/proposal-numeric-separator). This will allow number literals to have `_` to clarify (e.g., one billion can be `1_000_000_000` instead of `1000000000`).