### PR TITLE
feat: add cobertura reporting to coverage task

### DIFF
--- a/lib/tasks/coverage.js
+++ b/lib/tasks/coverage.js
@@ -36,7 +36,8 @@ const configure = function configure (gulp, opts, env) {
       }, {});
       const args = [
         '--reporter=lcov',
-        '--reporter=text-lcov',
+        '--reporter=text-lcov', // Coveralls consumes lcov and text-lcov reports
+        '--reporter=cobertura', // MS Azure consumes Cobertura coverage reports
         `--report-dir=${targetDir}`,
         '--exclude-after-remap=false',
         bins._mocha,


### PR DESCRIPTION
MS Azure can produce coverage reports, but it needs to have Cobertura reports.