### PR TITLE
fix: auth for GitHub

### DIFF
--- a/lib/tasks/ci.js
+++ b/lib/tasks/ci.js
@@ -25,8 +25,6 @@ const OUTPUT_INTERVAL = 60000;
 const MOCHA_PARALLEL_TEST_BROKEN_LINE = `if (value.type === 'test') {`;
 const MOCHA_PARALLEL_TEST_FIXED_LINE = `if (value.type === 'test') {\n        delete value.fn;`;
 
-const octokit = new Octokit();
-
 const configure = function configure (gulp, opts) {
   const owner = opts.ci.owner || GITHUB_OWNER;
   const repo = opts.ci.repo || GITHUB_REPO;
@@ -55,24 +53,14 @@ const configure = function configure (gulp, opts) {
     }
   });
 
-
-  gulp.task('github:authenticate', function githubAuthenticate (done) {
+  gulp.task('github:upload', async function githubUpload () {
     const githubToken = process.env.GITHUB_TOKEN;
-
     if (_.isEmpty(githubToken)) {
       log.warn('No GitHub token found in GITHUB_TOKEN environment variable');
       return;
     }
+    const octokit = new Octokit({auth: githubToken});
 
-    // this produces a deprecation notice, but the alternative does not work
-    octokit.authenticate({
-      type: 'token',
-      token: githubToken,
-    });
-    done();
-  });
-
-  gulp.task('github:upload', async function githubUpload () {
     const buildName = process.env.BUILD_NAME || `${Date.now()}`;
     const commitMessage = process.env.COMMIT_MESSAGE || 'No commit message provided';
 
@@ -125,9 +113,16 @@ const configure = function configure (gulp, opts) {
     }
   });
 
-  gulp.task('github-upload', gulp.series(['github:authenticate', 'github:upload']));
+  gulp.task('github-upload', gulp.series(['github:upload']));
 
   gulp.task('github:download', async function githubDownload () {
+    const githubToken = process.env.GITHUB_TOKEN;
+    if (_.isEmpty(githubToken)) {
+      log.warn('No GitHub token found in GITHUB_TOKEN environment variable');
+      return;
+    }
+    const octokit = new Octokit({auth: githubToken});
+
     log.info('Downloading GitHub asset');
     const tempDir = os.tmpdir();
     log.info(`Temporary directory for download: '${tempDir}'`);
@@ -188,7 +183,7 @@ const configure = function configure (gulp, opts) {
     log.info(`File uploaded: ${JSON.stringify(body)}`);
   });
 
-  gulp.task('sauce-storage-upload', gulp.series(['github:authenticate', 'github:download', 'saucelabs:upload']));
+  gulp.task('sauce-storage-upload', gulp.series(['github:download', 'saucelabs:upload']));
 
 
   /**


### PR DESCRIPTION
`[11:46:02] TypeError: octokit.authenticate is not a function` error happened in https://dev.azure.com/AppiumCI/Appium%20CI/_build/results?buildId=9257&view=logs&j=ac3a9155-aab6-5571-89fc-e58745898f84&t=2ee5aa70-d4cf-5015-ad3d-2d8b57eb2c5d

https://github.com/appium/appium-gulp-plugins/pull/116 has been merged so I think we can try the new method for authorisation again.

When I ran with a wrong token, I got the below message. The way to pass the token seems worked. Let me merge this and try https://github.com/appium/appium/blob/master/ci-jobs/templates/bundle-template.yml

```
kazu$ GITHUB_TOKEN='wrong' gulp github-upload
[00:19:11] Using gulpfile ~/GitHub/appium-gulp-plugins/gulpfile.js
[00:19:11] Starting 'github-upload'...
[00:19:11] Starting 'github:upload'...
[00:19:11] Creating release on 'appium/appium-build-store'
[00:19:11] Error uploading release asset: Bad credentials
[00:19:11] 'github:upload' errored after 309 ms
[00:19:11] Error: Error uploading release: Bad credentials
    at githubUpload (/Users/kazu/GitHub/appium-gulp-plugins/lib/tasks/ci.js:112:13)
    at process._tickCallback (internal/process/next_tick.js:68:7)
```

https://octokit.github.io/rest.js/v17