### PR TITLE
chore: Add json files to the transpilation list

### DIFF
--- a/lib/boilerplate.js
+++ b/lib/boilerplate.js
@@ -10,7 +10,14 @@ if (process.env.TRAVIS || process.env.CI) {
 }
 
 const DEFAULT_OPTS = {
-  files: ['*.js', 'lib/**/*.js', 'test/**/*.js', '!gulpfile.js'],
+  files: [
+    '*.js',
+    'lib/**/*.js',
+    'lib/**/*.json',
+    'test/**/*.js',
+    'test/**/*.json',
+    '!gulpfile.js',
+  ],
   transpile: true,
   transpileOut: 'build',
   typescript: false,


### PR DESCRIPTION
.json files could also be loaded by `require` or `import` directives, so it makes sense to include them into the list as well