### PR TITLE
chore: Lock mocha version until the testing issue is resolved

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "js-yaml": "^3.12.2",
     "lodash": "^4.0.1",
     "merge-stream": "^2.0.0",
-    "mocha": "^8.0.1",
+    "mocha": "~8.1.3",
     "moment": "^2.12.0",
     "node-notifier": "^8.0.0",
     "nyc": "^15.0.0",


### PR DESCRIPTION
I have reported the issue as https://github.com/mochajs/mocha/issues/4481 Lets lock the actual version until it is resolved, so we could continue running espresso tests. 